### PR TITLE
Fix tablet/mobile button icons and volume slider UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Click the music note icon in the ribbon (or run the **Toggle audio sidebar** com
 
 ## Limitations
 
-- **Desktop only** — no mobile/tablet support
+- **Mobile/tablet volume sliders** — on mobile and tablet, dragging volume sliders in editing mode may conflict with Obsidian's swipe-to-open-sidebar gesture. Switch to reading mode for smoother slider control.
 - **Local files only** — plays audio from your vault, not streaming services or URLs
 - **No seek/scrubber** — play, pause, and stop only; no jumping to a specific timestamp
 - **No weighted random** — `random: true` gives each track equal probability; no way to bias towards specific tracks

--- a/src/ui/player-controls.ts
+++ b/src/ui/player-controls.ts
@@ -22,10 +22,10 @@ export function createPlayerControls(
 ): PlayerControlsElements {
 	const container = parent.createDiv({cls: "rpg-audio-controls"});
 
-	const playPauseBtn = container.createEl("button", {cls: "rpg-audio-btn rpg-audio-play-btn"});
+	const playPauseBtn = container.createEl("button", {cls: "rpg-audio-btn rpg-audio-play-btn clickable-icon"});
 	setIcon(playPauseBtn, "play");
 
-	const stopBtn = container.createEl("button", {cls: "rpg-audio-btn rpg-audio-stop-btn"});
+	const stopBtn = container.createEl("button", {cls: "rpg-audio-btn rpg-audio-stop-btn clickable-icon"});
 	setIcon(stopBtn, "square");
 
 	const volumeSlider = container.createEl("input", {

--- a/src/ui/sidebar-view.ts
+++ b/src/ui/sidebar-view.ts
@@ -81,7 +81,7 @@ export class RpgAudioSidebarView extends ItemView {
 
 		const globalControls = titleRow.createDiv({cls: "rpg-audio-global-controls"});
 
-		this.globalFadeBtn = globalControls.createEl("button", {cls: "rpg-audio-btn"});
+		this.globalFadeBtn = globalControls.createEl("button", {cls: "rpg-audio-btn clickable-icon"});
 		this.globalFadeBtn.addEventListener("click", () => {
 			if (this.hasPlayingTracks()) {
 				this.manager.fadeOutAll(fadeDuration());
@@ -91,7 +91,7 @@ export class RpgAudioSidebarView extends ItemView {
 		});
 		this.updateFadeToggle(this.globalFadeBtn, this.hasPlayingTracks(), this.hasPausedTracks());
 
-		const stopAllBtn = globalControls.createEl("button", {cls: "rpg-audio-btn rpg-audio-stop-all-btn"});
+		const stopAllBtn = globalControls.createEl("button", {cls: "rpg-audio-btn rpg-audio-stop-all-btn clickable-icon"});
 		setIcon(stopAllBtn, "square");
 		stopAllBtn.setAttribute("aria-label", "Stop all");
 		stopAllBtn.addEventListener("click", () => this.manager.stopAll());
@@ -167,7 +167,7 @@ export class RpgAudioSidebarView extends ItemView {
 
 			const fadeDuration = () => Math.max(this.manager.crossfadeDuration, MIN_FADE_DURATION_MS);
 
-			const fadeToggleBtn = sectionHeader.createEl("button", {cls: "rpg-audio-btn rpg-audio-section-fade-btn"});
+			const fadeToggleBtn = sectionHeader.createEl("button", {cls: "rpg-audio-btn rpg-audio-section-fade-btn clickable-icon"});
 			fadeToggleBtn.addEventListener("click", (e) => {
 				e.stopPropagation();
 				if (this.hasPlayingTracksOfType(type)) {

--- a/styles.css
+++ b/styles.css
@@ -111,6 +111,7 @@
 	background: var(--background-modifier-border);
 	border-radius: 2px;
 	outline: none;
+	touch-action: pan-x;
 }
 
 .rpg-audio-volume::-webkit-slider-thumb {


### PR DESCRIPTION
## Summary
- Add Obsidian's `clickable-icon` class to all icon buttons, fixing invisible icons on tablet caused by `.is-tablet button:not(.clickable-icon)` padding override
- Add `touch-action: pan-x` to volume sliders to reduce conflicts with Obsidian's swipe-to-open-sidebar gesture on mobile
- Update README: remove "desktop only" caveat, document reading mode workaround for slider conflicts

Closes #5

## Test plan
- [ ] Verify button icons are visible on tablet-sized UI
- [ ] Verify volume sliders are draggable on mobile/tablet without triggering sidebar swipe (in reading mode)
- [ ] Verify desktop behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)