### PR TITLE
Fix sidebar evicting embedded track when hover popover closes

### DIFF
--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -346,6 +346,7 @@ export class AudioManager extends Events {
 			this.orphanTimers.delete(id);
 			const state = this.tracks.get(id);
 			if (!state) return;
+			if (this.hasLivePlayerElement(id)) return;
 			if (state.playState === PlayState.Playing || state.playState === PlayState.Paused) {
 				this.pendingOrphans.add(id);
 				return;
@@ -355,10 +356,23 @@ export class AudioManager extends Events {
 		this.orphanTimers.set(id, timer);
 	}
 
-	private cleanupIfOrphaned(id: string): void {
-		if (this.pendingOrphans.has(id)) {
-			this.unregister(id);
+	private hasLivePlayerElement(id: string): boolean {
+		const selector = `.rpg-audio-player[data-track-id="${CSS.escape(id)}"]`;
+		const elements = document.querySelectorAll<HTMLElement>(selector);
+		for (let i = 0; i < elements.length; i++) {
+			const el = elements[i];
+			if (el && el.isConnected) return true;
 		}
+		return false;
+	}
+
+	private cleanupIfOrphaned(id: string): void {
+		if (!this.pendingOrphans.has(id)) return;
+		if (this.hasLivePlayerElement(id)) {
+			this.pendingOrphans.delete(id);
+			return;
+		}
+		this.unregister(id);
 	}
 
 	private clearOrphanTimer(id: string): void {

--- a/src/ui/code-block-player.ts
+++ b/src/ui/code-block-player.ts
@@ -124,6 +124,7 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 		const el = this.containerEl;
 		el.empty();
 		el.addClass("rpg-audio-player");
+		el.dataset.trackId = this.def.id;
 
 		const header = el.createDiv({cls: "rpg-audio-header"});
 		const iconEl = header.createSpan({cls: "rpg-audio-icon"});


### PR DESCRIPTION
Fixes #8.

## Summary

- Tag each `RpgAudioCodeBlockPlayer`'s container with `data-track-id` so the audio manager can find live players by id.
- Before unregistering a track in `scheduleOrphanCheck`, scan the DOM for any still-connected `.rpg-audio-player[data-track-id="..."]`. If one exists, the track is still rendered somewhere (embed in the same note, another tab, another pane) and must not be evicted.
- Apply the same check in `cleanupIfOrphaned` so a track marked `pendingOrphan` while playing isn't evicted when stopped if another player still references it.

The scan runs at most once per orphan-check tick, scoped to a single CSS selector, so it is not in any hot path.

## Test plan

- [x] Repro the bug on `main`: embed a track and add a `[[link]]` to the same source note, hover the link, let the popover close, confirm sidebar evicts the track.
- [x] Confirm the bug is gone on this branch with the same repro.
- [x] Normal orphan cleanup still works: close the only tab containing a track, confirm sidebar clears after the timeout.
- [x] Inactive-tab behavior: open a track in tab A, switch to tab B, confirm sidebar still shows it.
- [x] `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)