### PR TITLE
Add autoplay support gated by a sidebar toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Turn your session prep notes into a soundboard — ambience, music, and sound ef
 - **Playlists** — list multiple files and they play in sequence, with optional looping
 - **Layered audio** — run ambience, music, and sound effects simultaneously with independent volume controls
 - **Fade controls** — fade in/out individual groups (e.g. fade out all ambience) or everything at once
+- **Autoplay** — mark tracks with `autoplay: true` and they start playing as soon as their note opens or is shown in a hover popover. Gated by a sidebar toggle so prep stays silent and you only flip it on at the start of a session
 - **Insert track command** — a GUI modal for building `rpg-audio` code blocks without remembering the syntax. Pick files from a fuzzy search, set type/loop/random, and insert the block at your cursor
 
 ## Use cases
@@ -61,6 +62,7 @@ This renders an inline player widget with play/pause, stop, and volume controls.
 | `type`  | No       | Label shown as a badge on the player (e.g. `sfx`, `ambience`, `playlist`). Defaults to `playlist` when multiple files are provided, `sfx` otherwise. |
 | `loop`  | No       | `true` or `false`. For single-file tracks, loops the file. For multi-file tracks, continues to the next track when one ends (sequentially or shuffled). When `false`, plays one track and stops. Defaults to `false`. |
 | `random` | No      | `true` or `false`. When enabled, picks a random track on play and (with `loop: true`) shuffles to a different track each time. Defaults to `false`. |
+| `autoplay` | No    | `true` or `false`. When enabled, the track starts playing as soon as it is rendered (e.g. when the note is opened or shown in a hover popover). Requires the sidebar autoplay toggle to be on — otherwise tracks marked `autoplay: true` stay silent until you press play. Existing `stops`/`pauses`/`starts` rules still apply, so autoplaying tracks of the same exclusive type will swap cleanly. Defaults to `false`. |
 | `stops`     | No   | Comma-separated list of types to stop when this track starts playing (e.g. `music, ambience`). If a crossfade duration is configured, the outgoing tracks fade out. |
 | `pauses`    | No   | Comma-separated list of types to pause when this track starts playing (e.g. `ambience`). Like `stops`, but paused tracks keep their position and can be resumed later. Fades out if crossfade is configured. |
 | `starts`    | No   | Comma-separated list of types to resume when this track starts playing (e.g. `ambience`). Resumes tracks that were previously paused. Fades in if crossfade is configured. |
@@ -227,7 +229,7 @@ Click the music note icon in the ribbon (or run the **Toggle audio sidebar** com
 
 - **Toggle audio sidebar** — show or hide the audio sidebar panel.
 - **Stop all audio** — stop all currently playing tracks.
-- **Insert audio track** — opens a modal to build and insert an `rpg-audio` code block at the cursor. Lets you set the name, type, files (via fuzzy search), loop, random, and advanced options (stops/pauses/starts) through a form instead of writing YAML by hand.
+- **Insert audio track** — opens a modal to build and insert an `rpg-audio` code block at the cursor. Lets you set the name, type, files (via fuzzy search), loop, random, autoplay, and advanced options (stops/pauses/starts) through a form instead of writing YAML by hand.
 
 ## Caveats
 

--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -6,6 +6,7 @@ import {
 	EVENT_TRACK_CHANGED,
 	EVENT_TRACKS_UPDATED,
 	EVENT_MASTER_VOLUME,
+	EVENT_ALLOW_AUTOPLAY,
 	ORPHAN_CHECK_DELAY_MS,
 } from "./types";
 import { FadeEngine } from "./fade-engine";
@@ -24,6 +25,7 @@ export class AudioManager extends Events {
 	private fadeMultipliers: Map<string, number> = new Map();
 	private _crossfadeDuration = 0;
 	private _playFadeDuration = 0;
+	private _allowAutoplay = false;
 	private playFades: Map<string, "out" | "in"> = new Map();
 
 	constructor(app: App) {
@@ -72,6 +74,16 @@ export class AudioManager extends Events {
 
 	set playFadeDuration(value: number) {
 		this._playFadeDuration = value;
+	}
+
+	get allowAutoplay(): boolean {
+		return this._allowAutoplay;
+	}
+
+	set allowAutoplay(value: boolean) {
+		if (this._allowAutoplay === value) return;
+		this._allowAutoplay = value;
+		this.trigger(EVENT_ALLOW_AUTOPLAY, value);
 	}
 
 	get masterVolume(): number {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,8 +18,9 @@ export default class RpgAudioPlugin extends Plugin {
 		this.audioManager.audioFolder = this.settings.audioFolder;
 		this.audioManager.crossfadeDuration = this.settings.crossfadeDuration;
 		this.audioManager.playFadeDuration = this.settings.playFadeDuration;
+		this.audioManager.allowAutoplay = this.settings.allowAutoplay;
 
-		this.registerView(SIDEBAR_VIEW_TYPE, (leaf) => new RpgAudioSidebarView(leaf, this.audioManager));
+		this.registerView(SIDEBAR_VIEW_TYPE, (leaf) => new RpgAudioSidebarView(leaf, this));
 
 		this.registerMarkdownCodeBlockProcessor("rpg-audio", (source, el, ctx) => {
 			const def = parseAudioBlock(source);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@ export interface RpgAudioSettings {
 	audioFolder: string;
 	masterVolume: number;
 	autoOpenSidebar: boolean;
+	allowAutoplay: boolean;
 	crossfadeDuration: number;
 	playFadeDuration: number;
 }
@@ -13,6 +14,7 @@ export const DEFAULT_SETTINGS: RpgAudioSettings = {
 	audioFolder: "audio",
 	masterVolume: 1.0,
 	autoOpenSidebar: true,
+	allowAutoplay: false,
 	crossfadeDuration: 2000,
 	playFadeDuration: 0,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface AudioTrackDef {
 	files: string[];
 	loop: boolean;
 	random: boolean;
+	autoplay: boolean;
 	stops: string[];
 	starts: string[];
 	pauses: string[];
@@ -27,6 +28,7 @@ export interface AudioTrackState {
 export const EVENT_TRACK_CHANGED = "track-changed";
 export const EVENT_TRACKS_UPDATED = "tracks-updated";
 export const EVENT_MASTER_VOLUME = "master-volume";
+export const EVENT_ALLOW_AUTOPLAY = "allow-autoplay";
 
 export const SIDEBAR_VIEW_TYPE = "rpg-audio-sidebar";
 

--- a/src/ui/code-block-player.ts
+++ b/src/ui/code-block-player.ts
@@ -11,6 +11,7 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 	let type = "";
 	let loop = false;
 	let random = false;
+	let autoplay = false;
 	let stops: string[] = [];
 	let starts: string[] = [];
 	let pauses: string[] = [];
@@ -49,6 +50,9 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 			case "random":
 				random = value === "true";
 				break;
+			case "autoplay":
+				autoplay = value === "true";
+				break;
 			case "stops":
 				if (value) {
 					stops = value.split(",").map(s => s.trim()).filter(s => s.length > 0);
@@ -77,7 +81,7 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 
 	if (!type) type = files.length > 1 ? "playlist" : "sfx";
 
-	return {id, name, type, files, loop, random, stops, starts, pauses};
+	return {id, name, type, files, loop, random, autoplay, stops, starts, pauses};
 }
 
 export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
@@ -94,6 +98,7 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 	}
 
 	onload(): void {
+		const wasRegistered = !!this.manager.getTrack(this.def.id);
 		this.manager.register(this.def);
 		this.buildUI();
 
@@ -104,6 +109,10 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 		this.eventRef = () => this.manager.off(EVENT_TRACK_CHANGED, handler);
 
 		this.syncState();
+
+		if (this.def.autoplay && !wasRegistered && this.manager.allowAutoplay) {
+			void this.manager.play(this.def.id);
+		}
 
 		// Obsidian does not call onunload for MarkdownRenderChild inside
 		// ![[...]] transclusions. Poll for DOM detachment as a fallback.

--- a/src/ui/insert-track-modal.ts
+++ b/src/ui/insert-track-modal.ts
@@ -23,6 +23,7 @@ function generateCodeBlock(opts: {
 	files: string[];
 	loop: boolean;
 	random: boolean;
+	autoplay: boolean;
 	stops: string;
 	pauses: string;
 	starts: string;
@@ -33,6 +34,7 @@ function generateCodeBlock(opts: {
 	lines.push(`type: ${opts.type}`);
 	if (opts.loop) lines.push("loop: true");
 	if (opts.random) lines.push("random: true");
+	if (opts.autoplay) lines.push("autoplay: true");
 	if (opts.stops.trim()) lines.push(`stops: ${opts.stops.trim()}`);
 	if (opts.pauses.trim()) lines.push(`pauses: ${opts.pauses.trim()}`);
 	if (opts.starts.trim()) lines.push(`starts: ${opts.starts.trim()}`);
@@ -85,6 +87,7 @@ export class InsertTrackModal extends Modal {
 	private selectedFiles: string[] = [];
 	private loop = false;
 	private random = false;
+	private autoplay = false;
 	private stops = "";
 	private pauses = "";
 	private starts = "";
@@ -189,6 +192,13 @@ export class InsertTrackModal extends Modal {
 			.addToggle(toggle => toggle
 				.setValue(this.random)
 				.onChange(value => { this.random = value; }));
+
+		new Setting(contentEl)
+			.setName("Autoplay")
+			.setDesc("Start playing as soon as the track is rendered, like when opening a note or hovering a link popover")
+			.addToggle(toggle => toggle
+				.setValue(this.autoplay)
+				.onChange(value => { this.autoplay = value; }));
 
 		// Advanced section
 		contentEl.createEl("details", {}, details => {
@@ -301,6 +311,7 @@ export class InsertTrackModal extends Modal {
 			files: this.selectedFiles,
 			loop: this.loop,
 			random: this.random,
+			autoplay: this.autoplay,
 			stops: this.stops,
 			pauses: this.pauses,
 			starts: this.starts,

--- a/src/ui/sidebar-view.ts
+++ b/src/ui/sidebar-view.ts
@@ -1,28 +1,33 @@
 import {ItemView, WorkspaceLeaf, setIcon} from "obsidian";
 import {AudioManager} from "../audio-manager";
+import type RpgAudioPlugin from "../main";
 import {
 	PlayState,
 	SIDEBAR_VIEW_TYPE,
 	EVENT_TRACK_CHANGED,
 	EVENT_TRACKS_UPDATED,
 	EVENT_MASTER_VOLUME,
+	EVENT_ALLOW_AUTOPLAY,
 	AudioTrackState,
 	MIN_FADE_DURATION_MS,
 } from "../types";
 import {createPlayerControls, updatePlayPauseButton, PlayerControlsElements} from "./player-controls";
 
 export class RpgAudioSidebarView extends ItemView {
+	private plugin: RpgAudioPlugin;
 	private manager: AudioManager;
 	private trackRows: Map<string, {rowEl: HTMLElement; controls: PlayerControlsElements; statusEl: HTMLElement}> = new Map();
 	private contentArea: HTMLElement | null = null;
 	private masterSlider: HTMLInputElement | null = null;
+	private autoplayBtn: HTMLElement | null = null;
 	private collapsedGroups: Set<string> = new Set();
 	private globalFadeBtn: HTMLElement | null = null;
 	private typeFadeBtns: Map<string, HTMLElement> = new Map();
 
-	constructor(leaf: WorkspaceLeaf, manager: AudioManager) {
+	constructor(leaf: WorkspaceLeaf, plugin: RpgAudioPlugin) {
 		super(leaf);
-		this.manager = manager;
+		this.plugin = plugin;
+		this.manager = plugin.audioManager;
 	}
 
 	getViewType(): string {
@@ -46,6 +51,7 @@ export class RpgAudioSidebarView extends ItemView {
 		this.buildHeader(container);
 		this.contentArea = container.createDiv({cls: "rpg-audio-sidebar-content"});
 		this.renderAll();
+		this.buildFooter(container);
 
 		this.registerEvent(
 			this.manager.on(EVENT_TRACKS_UPDATED, () => this.renderAll())
@@ -61,12 +67,16 @@ export class RpgAudioSidebarView extends ItemView {
 				if (this.masterSlider) this.masterSlider.value = String(vol);
 			})
 		);
+		this.registerEvent(
+			this.manager.on(EVENT_ALLOW_AUTOPLAY, () => this.updateAutoplayBtn())
+		);
 	}
 
 	async onClose(): Promise<void> {
 		this.trackRows.clear();
 		this.contentArea = null;
 		this.masterSlider = null;
+		this.autoplayBtn = null;
 		this.globalFadeBtn = null;
 		this.typeFadeBtns.clear();
 	}
@@ -80,6 +90,10 @@ export class RpgAudioSidebarView extends ItemView {
 		const fadeDuration = () => Math.max(this.manager.crossfadeDuration, MIN_FADE_DURATION_MS);
 
 		const globalControls = titleRow.createDiv({cls: "rpg-audio-global-controls"});
+
+		this.autoplayBtn = globalControls.createEl("button", {cls: "rpg-audio-btn clickable-icon"});
+		this.autoplayBtn.addEventListener("click", () => void this.toggleAutoplay());
+		this.updateAutoplayBtn();
 
 		this.globalFadeBtn = globalControls.createEl("button", {cls: "rpg-audio-btn clickable-icon"});
 		this.globalFadeBtn.addEventListener("click", () => {
@@ -111,6 +125,19 @@ export class RpgAudioSidebarView extends ItemView {
 		this.masterSlider.addEventListener("input", () => {
 			this.manager.masterVolume = parseFloat(this.masterSlider!.value);
 		});
+	}
+
+	private buildFooter(container: HTMLElement): void {
+		const footer = container.createDiv({cls: "rpg-audio-sidebar-footer"});
+		footer.createSpan({
+			cls: "rpg-audio-sidebar-version",
+			text: `v${this.plugin.manifest.version}`,
+		});
+		const settingsBtn = footer.createEl("button", {cls: "rpg-audio-btn clickable-icon"});
+		setIcon(settingsBtn, "settings");
+		// eslint-disable-next-line obsidianmd/ui/sentence-case
+		settingsBtn.setAttribute("aria-label", "Open RPG Audio settings");
+		settingsBtn.addEventListener("click", () => this.openSettings());
 	}
 
 	private renderAll(): void {
@@ -259,6 +286,26 @@ export class RpgAudioSidebarView extends ItemView {
 			btn.setAttribute("aria-label", "Fade out");
 			btn.addClass("rpg-audio-btn-disabled");
 		}
+	}
+
+	private updateAutoplayBtn(): void {
+		if (!this.autoplayBtn) return;
+		const on = this.manager.allowAutoplay;
+		setIcon(this.autoplayBtn, on ? "zap" : "zap-off");
+		this.autoplayBtn.setAttribute("aria-label", on ? "Autoplay enabled (click to disable)" : "Autoplay disabled (click to enable)");
+		this.autoplayBtn.toggleClass("is-active", on);
+	}
+
+	private async toggleAutoplay(): Promise<void> {
+		this.plugin.settings.allowAutoplay = !this.plugin.settings.allowAutoplay;
+		this.manager.allowAutoplay = this.plugin.settings.allowAutoplay;
+		await this.plugin.saveSettings();
+	}
+
+	private openSettings(): void {
+		const setting = (this.plugin.app as unknown as { setting: { open: () => void; openTabById: (id: string) => void } }).setting;
+		setting.open();
+		setting.openTabById(this.plugin.manifest.id);
 	}
 
 	private updateFadeButtons(): void {

--- a/styles.css
+++ b/styles.css
@@ -150,7 +150,10 @@
 /* Sidebar */
 .rpg-audio-sidebar {
 	padding: 0;
-	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
 }
 
 .rpg-audio-sidebar-header {
@@ -204,6 +207,28 @@
 
 .rpg-audio-sidebar-content {
 	padding: 8px 12px;
+	flex: 1;
+	overflow-y: auto;
+	min-height: 0;
+}
+
+.rpg-audio-sidebar-footer {
+	padding: 6px 12px;
+	border-top: 1px solid var(--background-modifier-border);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	opacity: 0.6;
+	transition: opacity 0.15s ease;
+}
+
+.rpg-audio-sidebar-footer:hover {
+	opacity: 1;
+}
+
+.rpg-audio-sidebar-version {
+	font-size: 0.8em;
+	color: var(--text-muted);
 }
 
 .rpg-audio-sidebar-section {


### PR DESCRIPTION
## Summary
- New per-track `autoplay: true` field — tracks start playing as soon as their code block renders (note open or hover popover), making the TTRPG-Maps marker → hover-popover → audio flow seamless
- Gated by a global sidebar toggle (default off) so session prep stays silent. The toggle lives in the sidebar header (`zap` / `zap-off`) — flip it on at the start of a session, off at the end
- Existing `stops`/`pauses`/`starts` rules apply to autoplaying tracks, so same-type conflicts swap cleanly
- Sidebar gets a footer with the plugin version and the settings gear (moved out of the title row to declutter)
- Insert-track modal exposes the new field; README documents it

## Test plan
- [x] With sidebar autoplay off, opening a note containing `autoplay: true` tracks does not start playback
- [x] With sidebar autoplay on, opening such a note starts playback
- [x] Hovering a TTRPG-Maps marker whose note has an `autoplay: true` track starts playback (sidebar autoplay on)
- [x] Hovering quickly between two markers with mutual `stops:` swaps cleanly via existing crossfade
- [x] Re-rendering the same code block (edit-mode toggle, repeated popover hover) does not retrigger autoplay
- [x] Toggling autoplay via the sidebar button persists across reloads
- [x] Gear icon in the footer opens **Settings → RPG Audio**
- [x] Footer shows the current plugin version
- [ ] Sidebar footer stays pinned to the bottom even with many tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)