### PR TITLE
Rename "starts" attribute to "resumes" (with backwards-compatible alias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Turn your session prep notes into a soundboard — ambience, music, and sound ef
 
 - **Inline players** — add `rpg-audio` code blocks to any note and get play/pause, stop, and volume controls right next to your encounter text
 - **Sidebar** — a dedicated panel showing all tracks grouped by type, with global and per-group fade controls
-- **Crossfade** — tracks with `stops:`, `pauses:`, or `starts:` automatically crossfade between each other (configurable duration, or instant)
+- **Crossfade** — tracks with `stops:`, `pauses:`, or `resumes:` automatically crossfade between each other (configurable duration, or instant)
 - **Playlists** — list multiple files and they play in sequence, with optional looping
 - **Layered audio** — run ambience, music, and sound effects simultaneously with independent volume controls
 - **Fade controls** — fade in/out individual groups (e.g. fade out all ambience) or everything at once
@@ -20,7 +20,7 @@ Turn your session prep notes into a soundboard — ambience, music, and sound ef
 
 - **GMs who prep in Obsidian** — embed audio controls right next to your encounter notes. When the party enters the tavern, hit play without alt-tabbing.
 - **Layered soundscapes** — run rain ambience, tavern chatter, and a bard's tune simultaneously, each with its own volume.
-- **One-click scene transitions** — use `stops:` to crossfade from exploration music to battle music with a single button press. Use `pauses:` and `starts:` for temporary transitions that resume where they left off.
+- **One-click scene transitions** — use `stops:` to crossfade from exploration music to battle music with a single button press. Use `pauses:` and `resumes:` for temporary transitions that resume where they left off.
 - **Solo RPG / journaling** — set the mood for your solo sessions.
 
 ## Quick start
@@ -62,10 +62,10 @@ This renders an inline player widget with play/pause, stop, and volume controls.
 | `type`  | No       | Label shown as a badge on the player (e.g. `sfx`, `ambience`, `playlist`). Defaults to `playlist` when multiple files are provided, `sfx` otherwise. |
 | `loop`  | No       | `true` or `false`. For single-file tracks, loops the file. For multi-file tracks, continues to the next track when one ends (sequentially or shuffled). When `false`, plays one track and stops. Defaults to `false`. |
 | `random` | No      | `true` or `false`. When enabled, picks a random track on play and (with `loop: true`) shuffles to a different track each time. Defaults to `false`. |
-| `autoplay` | No    | `true` or `false`. When enabled, the track starts playing as soon as it is rendered (e.g. when the note is opened or shown in a hover popover). Requires the sidebar autoplay toggle to be on — otherwise tracks marked `autoplay: true` stay silent until you press play. Existing `stops`/`pauses`/`starts` rules still apply, so autoplaying tracks of the same exclusive type will swap cleanly. Defaults to `false`. |
+| `autoplay` | No    | `true` or `false`. When enabled, the track starts playing as soon as it is rendered (e.g. when the note is opened or shown in a hover popover). Requires the sidebar autoplay toggle to be on — otherwise tracks marked `autoplay: true` stay silent until you press play. Existing `stops`/`pauses`/`resumes` rules still apply, so autoplaying tracks of the same exclusive type will swap cleanly. Defaults to `false`. |
 | `stops`     | No   | Comma-separated list of types to stop when this track starts playing (e.g. `music, ambience`). If a crossfade duration is configured, the outgoing tracks fade out. |
 | `pauses`    | No   | Comma-separated list of types to pause when this track starts playing (e.g. `ambience`). Like `stops`, but paused tracks keep their position and can be resumed later. Fades out if crossfade is configured. |
-| `starts`    | No   | Comma-separated list of types to resume when this track starts playing (e.g. `ambience`). Resumes tracks that were previously paused. Fades in if crossfade is configured. |
+| `resumes`   | No   | Comma-separated list of types to resume when this track starts playing (e.g. `ambience`). Only affects tracks that are currently paused — stopped tracks are not started. Fades in if crossfade is configured. Accepts `starts:` as a deprecated alias. |
 | `file`  | \*       | Path to a single audio file, relative to the vault root (e.g. `audio/thunder.mp3`). |
 | `files` | \*       | A list of audio files (one per line, prefixed with `- `). Files play in order as a playlist. |
 
@@ -191,7 +191,7 @@ file: audio/sfx/door-open.mp3
 id: exit-house
 name: Exit House
 type: sfx
-starts: ambience
+resumes: ambience
 file: audio/sfx/door-close.mp3
 ```
 ````
@@ -212,7 +212,7 @@ Click the music note icon in the ribbon (or run the **Toggle audio sidebar** com
 ## Tips
 
 - Use `stops: music` on all your music tracks so only one plays at a time — switching scenes is a single click
-- Use `pauses:` and `starts:` for temporary scene changes (e.g. entering/leaving a building) where you want audio to resume from where it left off
+- Use `pauses:` and `resumes:` for temporary scene changes (e.g. entering/leaving a building) where you want audio to resume from where it left off
 - Keep ambience and SFX as separate types so you can fade out ambience without killing sound effects
 - Organize your audio folder by type: `audio/music/`, `audio/ambience/`, `audio/sfx/`
 - File paths can be absolute from the vault root (`audio/music/tavern.mp3`) or relative to the configured audio folder (`music/tavern.mp3`)
@@ -229,7 +229,7 @@ Click the music note icon in the ribbon (or run the **Toggle audio sidebar** com
 
 - **Toggle audio sidebar** — show or hide the audio sidebar panel.
 - **Stop all audio** — stop all currently playing tracks.
-- **Insert audio track** — opens a modal to build and insert an `rpg-audio` code block at the cursor. Lets you set the name, type, files (via fuzzy search), loop, random, autoplay, and advanced options (stops/pauses/starts) through a form instead of writing YAML by hand.
+- **Insert audio track** — opens a modal to build and insert an `rpg-audio` code block at the cursor. Lets you set the name, type, files (via fuzzy search), loop, random, autoplay, and advanced options (stops/pauses/resumes) through a form instead of writing YAML by hand.
 
 ## Caveats
 

--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -188,14 +188,14 @@ export class AudioManager extends Events {
 			}
 		}
 
-		if (state.def.starts.length > 0) {
+		if (state.def.resumes.length > 0) {
 			for (const [otherId, other] of this.tracks) {
-				if (otherId !== id && state.def.starts.includes(other.def.type) && other.playState === PlayState.Paused) {
+				if (otherId !== id && state.def.resumes.includes(other.def.type) && other.playState === PlayState.Paused) {
 					if (this._crossfadeDuration > 0) {
 						this.play(otherId, true).then(() => {
 							this.fadeIn(otherId, this._crossfadeDuration);
 						}).catch((e) => {
-							console.error(`RPG Audio: starts fade-in failed for "${otherId}"`, e);
+							console.error(`RPG Audio: resumes fade-in failed for "${otherId}"`, e);
 						});
 					} else {
 						void this.play(otherId);

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export interface AudioTrackDef {
 	random: boolean;
 	autoplay: boolean;
 	stops: string[];
-	starts: string[];
+	resumes: string[];
 	pauses: string[];
 }
 

--- a/src/ui/code-block-player.ts
+++ b/src/ui/code-block-player.ts
@@ -13,7 +13,7 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 	let random = false;
 	let autoplay = false;
 	let stops: string[] = [];
-	let starts: string[] = [];
+	let resumes: string[] = [];
 	let pauses: string[] = [];
 	const files: string[] = [];
 	let inFilesList = false;
@@ -58,9 +58,10 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 					stops = value.split(",").map(s => s.trim()).filter(s => s.length > 0);
 				}
 				break;
-			case "starts":
+			case "resumes":
+			case "starts": // deprecated alias for `resumes`, kept for backwards compatibility
 				if (value) {
-					starts = value.split(",").map(s => s.trim()).filter(s => s.length > 0);
+					resumes = value.split(",").map(s => s.trim()).filter(s => s.length > 0);
 				}
 				break;
 			case "pauses":
@@ -81,7 +82,7 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 
 	if (!type) type = files.length > 1 ? "playlist" : "sfx";
 
-	return {id, name, type, files, loop, random, autoplay, stops, starts, pauses};
+	return {id, name, type, files, loop, random, autoplay, stops, resumes, pauses};
 }
 
 export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {

--- a/src/ui/insert-track-modal.ts
+++ b/src/ui/insert-track-modal.ts
@@ -26,7 +26,7 @@ function generateCodeBlock(opts: {
 	autoplay: boolean;
 	stops: string;
 	pauses: string;
-	starts: string;
+	resumes: string;
 }): string {
 	const lines: string[] = [];
 	lines.push(`id: ${opts.id}`);
@@ -37,7 +37,7 @@ function generateCodeBlock(opts: {
 	if (opts.autoplay) lines.push("autoplay: true");
 	if (opts.stops.trim()) lines.push(`stops: ${opts.stops.trim()}`);
 	if (opts.pauses.trim()) lines.push(`pauses: ${opts.pauses.trim()}`);
-	if (opts.starts.trim()) lines.push(`starts: ${opts.starts.trim()}`);
+	if (opts.resumes.trim()) lines.push(`resumes: ${opts.resumes.trim()}`);
 
 	if (opts.files.length === 1) {
 		lines.push(`file: ${opts.files[0]}`);
@@ -90,7 +90,7 @@ export class InsertTrackModal extends Modal {
 	private autoplay = false;
 	private stops = "";
 	private pauses = "";
-	private starts = "";
+	private resumes = "";
 
 	private fileListEl: HTMLElement | null = null;
 	private insertBtn: HTMLButtonElement | null = null;
@@ -221,12 +221,12 @@ export class InsertTrackModal extends Modal {
 					.onChange(value => { this.pauses = value; }));
 
 			new Setting(details)
-				.setName("Starts")
+				.setName("Resumes")
 				.setDesc("Comma-separated types to resume when this plays")
 				.addText(text => text
 					// eslint-disable-next-line obsidianmd/ui/sentence-case
 					.setPlaceholder("ambience")
-					.onChange(value => { this.starts = value; }));
+					.onChange(value => { this.resumes = value; }));
 		});
 
 		// Insert button
@@ -314,7 +314,7 @@ export class InsertTrackModal extends Modal {
 			autoplay: this.autoplay,
 			stops: this.stops,
 			pauses: this.pauses,
-			starts: this.starts,
+			resumes: this.resumes,
 		});
 		this.onInsert(block);
 		this.close();


### PR DESCRIPTION
## Summary
- Renames the `starts:` code-block attribute to `resumes:`, which more accurately describes its behavior — it only resumes already-paused tracks of the matching type, it does not start stopped tracks.
- The parser still accepts `starts:` as a deprecated alias, so existing notes keep working without changes.
- Internal field, modal field/label, and docs all use `resumes` as the canonical name.

## Test plan
- [ ] Existing note with `starts: ambience` still resumes paused ambience tracks
- [ ] New note with `resumes: ambience` behaves the same
- [ ] Insert-track modal emits `resumes:` for newly inserted blocks
- [ ] Crossfade still fades in resumed tracks when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)