### PR TITLE
Add scope field, debug overlay, and orphan-cleanup fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,20 @@ Turn your session prep notes into a soundboard — ambience, music, and sound ef
 
 - **Inline players** — add `rpg-audio` code blocks to any note and get play/pause, stop, and volume controls right next to your encounter text
 - **Sidebar** — a dedicated panel showing all tracks grouped by type, with global and per-group fade controls
-- **Crossfade** — tracks with `stops:`, `pauses:`, or `resumes:` automatically crossfade between each other (configurable duration, or instant)
+- **Scene transitions via `scope:`** — label tracks with one or more context tags; playing a scoped track automatically stops tracks from other scopes
+- **Crossfade** — exclusive transitions fade smoothly (configurable duration, or instant)
 - **Playlists** — list multiple files and they play in sequence, with optional looping
 - **Layered audio** — run ambience, music, and sound effects simultaneously with independent volume controls
 - **Fade controls** — fade in/out individual groups (e.g. fade out all ambience) or everything at once
 - **Autoplay** — mark tracks with `autoplay: true` and they start playing as soon as their note opens or is shown in a hover popover. Gated by a sidebar toggle so prep stays silent and you only flip it on at the start of a session
-- **Insert track command** — a GUI modal for building `rpg-audio` code blocks without remembering the syntax. Pick files from a fuzzy search, set type/loop/random, and insert the block at your cursor
+- **Insert track command** — a GUI modal for building `rpg-audio` code blocks without remembering the syntax
+- **Debug overlay** — optional sidebar toggle that shows each track's last event and the active scope set, useful when audio behaves unexpectedly
 
 ## Use cases
 
 - **GMs who prep in Obsidian** — embed audio controls right next to your encounter notes. When the party enters the tavern, hit play without alt-tabbing.
 - **Layered soundscapes** — run rain ambience, tavern chatter, and a bard's tune simultaneously, each with its own volume.
-- **One-click scene transitions** — use `stops:` to crossfade from exploration music to battle music with a single button press. Use `pauses:` and `resumes:` for temporary transitions that resume where they left off.
+- **Scene-based audio** — tag tracks by location or context with `scope:`. Switching scenes is a single click and the previous scene's audio steps aside automatically.
 - **Solo RPG / journaling** — set the mood for your solo sessions.
 
 ## Quick start
@@ -39,52 +41,9 @@ file: audio/tavern.mp3
 
 3. Switch to reading mode — hit play
 
-## Usage
+## Common patterns
 
-Add an `rpg-audio` fenced code block to any note to create an audio player:
-
-````markdown
-```rpg-audio
-id: tavern-music
-name: Tavern Music
-file: audio/tavern-ambience.mp3
-```
-````
-
-This renders an inline player widget with play/pause, stop, and volume controls.
-
-### Fields
-
-| Field   | Required | Description |
-|---------|----------|-------------|
-| `id`    | Yes      | Unique identifier for the track. Used internally to manage playback state. |
-| `name`  | Yes      | Display name shown in the player widget and sidebar. |
-| `type`  | No       | Label shown as a badge on the player (e.g. `sfx`, `ambience`, `playlist`). Defaults to `playlist` when multiple files are provided, `sfx` otherwise. |
-| `loop`  | No       | `true` or `false`. For single-file tracks, loops the file. For multi-file tracks, continues to the next track when one ends (sequentially or shuffled). When `false`, plays one track and stops. Defaults to `false`. |
-| `random` | No      | `true` or `false`. When enabled, picks a random track on play and (with `loop: true`) shuffles to a different track each time. Defaults to `false`. |
-| `autoplay` | No    | `true` or `false`. When enabled, the track starts playing as soon as it is rendered (e.g. when the note is opened or shown in a hover popover). Requires the sidebar autoplay toggle to be on — otherwise tracks marked `autoplay: true` stay silent until you press play. Existing `stops`/`pauses`/`resumes` rules still apply, so autoplaying tracks of the same exclusive type will swap cleanly. Defaults to `false`. |
-| `stops`     | No   | Comma-separated list of types **or track IDs** to stop when this track starts playing (e.g. `music, ambience`, or `crowd-ambience` to target one specific track). Prefix a token with `!` to exclude (e.g. `stops: ambient, !crowd-ambience` = stop all ambient tracks except `crowd-ambience`). If a crossfade duration is configured, the outgoing tracks fade out. |
-| `pauses`    | No   | Comma-separated list of types **or track IDs** to pause when this track starts playing (e.g. `ambience`, or `tavern-music`). Supports `!` exclusions (see `stops`). Like `stops`, but paused tracks keep their position and can be resumed later. Fades out if crossfade is configured. |
-| `resumes`   | No   | Comma-separated list of types **or track IDs** to resume when this track starts playing (e.g. `ambience`, or `crowd-ambience`). Supports `!` exclusions (see `stops`). Only affects tracks that are currently paused — stopped tracks are not started. Fades in if crossfade is configured. Accepts `starts:` as a deprecated alias. |
-| `file`  | \*       | Path to a single audio file, relative to the vault root (e.g. `audio/thunder.mp3`). |
-| `files` | \*       | A list of audio files (one per line, prefixed with `- `). Files play in order as a playlist. |
-
-\* At least one `file` or `files` entry is required.
-
-### Examples
-
-**Sound effect (one-shot):**
-
-````markdown
-```rpg-audio
-id: thunder
-name: Thunder Clap
-type: sfx
-file: audio/sfx/thunder.mp3
-```
-````
-
-**Looping ambience:**
+### A single looping track
 
 ````markdown
 ```rpg-audio
@@ -96,75 +55,129 @@ file: audio/ambience/rain.mp3
 ```
 ````
 
-**Playlist:**
+### A layered scene (music + ambience + sfx)
 
-````markdown
-```rpg-audio
-id: battle-music
-name: Battle Music
-type: playlist
-loop: true
-files:
-- audio/music/battle-01.mp3
-- audio/music/battle-02.mp3
-- audio/music/battle-03.mp3
-```
-````
-
-Add `loop: true` to play through all tracks in order and repeat. Without it, only one track plays and stops.
-
-**Shuffled playlist:**
-
-````markdown
-```rpg-audio
-id: battle-music
-name: Battle Music
-type: playlist
-loop: true
-random: true
-files:
-- audio/music/battle-01.mp3
-- audio/music/battle-02.mp3
-- audio/music/battle-03.mp3
-```
-````
-
-With `random: true`, playback starts on a random track and shuffles to a different track each time one ends. Resuming from pause keeps the current track.
-
-**Randomized sound effect (one-shot):**
-
-````markdown
-```rpg-audio
-id: sword-hit
-name: Sword Hit
-type: sfx
-random: true
-loop: false
-files:
-- audio/sfx/sword-hit-01.mp3
-- audio/sfx/sword-hit-02.mp3
-- audio/sfx/sword-hit-03.mp3
-```
-````
-
-With `random: true` and `loop: false`, each press of play triggers a random sound from the list. Great for varied sound effects.
-
-**Music tracks that stop other music (only one plays at a time):**
+Define multiple tracks in the same note. They share controls but play independently, each with its own volume.
 
 ````markdown
 ```rpg-audio
 id: tavern-music
 name: Tavern Music
 type: music
-stops: music
 loop: true
 file: audio/music/tavern.mp3
 ```
+
+```rpg-audio
+id: tavern-chatter
+name: Tavern Chatter
+type: ambience
+loop: true
+file: audio/ambience/tavern-chatter.mp3
+```
+
+```rpg-audio
+id: door-creak
+name: Door Creak
+type: sfx
+file: audio/sfx/door-creak.mp3
+```
 ````
 
-With `stops: music`, starting this track will automatically stop any other playing track that has `type: music`. You can list multiple types separated by commas (e.g. `stops: music, ambience`). If a crossfade duration is configured in settings, the outgoing tracks fade out while the new one fades in.
+### Scene transitions with `scope:`
 
-**Scene transitions with pause/resume:**
+`scope:` is a comma-separated list of context labels (any strings you choose). When a scoped track starts playing, the engine sets the **active scope** to that track's labels and stops any other playing track whose scope isn't a subset of the new active set. Tracks with the same scope coexist; tracks without a `scope:` are unaffected by transitions.
+
+````markdown
+```rpg-audio
+id: tavern-music
+name: Tavern Music
+type: music
+scope: tavern
+loop: true
+file: audio/music/tavern.mp3
+```
+
+```rpg-audio
+id: tavern-amb
+name: Tavern Ambience
+type: ambience
+scope: tavern
+loop: true
+file: audio/ambience/tavern-chatter.mp3
+```
+
+```rpg-audio
+id: forest-music
+name: Forest Music
+type: music
+scope: forest
+loop: true
+file: audio/music/forest.mp3
+```
+````
+
+Starting `tavern-music` plays alongside `tavern-amb` (same scope). When you later trigger `forest-music`, both tavern tracks stop automatically — no per-track directives needed.
+
+Multi-scope is supported: `scope: outdoors, district-1` means the track belongs to *both* contexts. It keeps playing as long as every label it claims is part of the active scope. So a track scoped `outdoors` survives transitions between any `outdoors, …` scopes (handy for weather beds and region-spanning atmospheres).
+
+### Playlists
+
+````markdown
+```rpg-audio
+id: battle-music
+name: Battle Music
+type: playlist
+loop: true
+files:
+- audio/music/battle-01.mp3
+- audio/music/battle-02.mp3
+- audio/music/battle-03.mp3
+```
+````
+
+Add `random: true` to shuffle. Without `loop: true`, only one track plays and stops — paired with `random: true` this gives you a varied one-shot SFX (e.g. sword hits).
+
+## Sidebar
+
+Click the music note icon in the ribbon (or run the **Toggle audio sidebar** command) to open a sidebar panel. The sidebar shows:
+
+- **Global controls** — Fade In All, Fade Out All, and Stop All buttons
+- **Master volume slider** — controls the global volume for all tracks
+- **Tracks grouped by type** — collapsible sections for each type (music, ambience, sfx, etc.)
+- **Per-group fade controls** — fade in or fade out all tracks of a specific type
+- **Per-track controls** — play/pause, stop, and volume slider for each track
+- **Playlist status** — current position for multi-file tracks (e.g. "Playing 2/5")
+- **Debug toggle** — bug icon in the footer reveals scope labels, last-event info per track, and the active scope set
+
+## Field reference
+
+| Field   | Required | Description |
+|---------|----------|-------------|
+| `id`    | Yes      | Unique identifier for the track. Used internally to manage playback state. |
+| `name`  | Yes      | Display name shown in the player widget and sidebar. |
+| `type`  | No       | Label shown as a badge on the player (e.g. `sfx`, `ambience`, `playlist`). Defaults to `playlist` when multiple files are provided, `sfx` otherwise. |
+| `scope` | No       | Comma-separated context labels (e.g. `tavern` or `outdoors, district-1`). Playing a scoped track stops other-scope tracks. See [Scene transitions with scope](#scene-transitions-with-scope). |
+| `loop`  | No       | `true` or `false`. For single-file tracks, loops the file. For multi-file tracks, continues to the next track when one ends (sequentially or shuffled). When `false`, plays one track and stops. Defaults to `false`. |
+| `random` | No      | `true` or `false`. When enabled, picks a random track on play and (with `loop: true`) shuffles to a different track each time. Defaults to `false`. |
+| `autoplay` | No    | `true` or `false`. When enabled, the track starts playing as soon as it is rendered (e.g. when the note is opened or shown in a hover popover). Requires the sidebar autoplay toggle to be on. Defaults to `false`. |
+| `stops`     | No   | Comma-separated list of types or track IDs to stop when this track starts playing. Prefix a token with `!` to exclude. See [Advanced directives](#advanced-directives). |
+| `pauses`    | No   | Like `stops`, but paused tracks keep their position and can be resumed later. |
+| `resumes`   | No   | Comma-separated list of types or track IDs to resume when this track starts. Only affects tracks that are currently paused. |
+| `file`  | \*       | Path to a single audio file, relative to the vault root (e.g. `audio/thunder.mp3`). |
+| `files` | \*       | A list of audio files (one per line, prefixed with `- `). Files play in order as a playlist. |
+
+\* At least one `file` or `files` entry is required.
+
+## Advanced directives
+
+Most scene-transition use cases are covered by `scope:`. The `stops:` / `pauses:` / `resumes:` directives remain useful for:
+
+- **One-shot SFX that pauses background audio** — a door-open sfx that pauses ambience until a matching door-close sfx resumes it. This needs explicit pause/resume because you want resume-from-position behavior, which scope's stop semantics don't provide.
+- **Cross-cutting exceptions** — silence a global music bed during a dramatic NPC theme without giving the bed a scope.
+- **Surgical per-id targeting** — `stops: <some-id>` to stop one specific track when this one plays.
+
+### Pause-and-resume SFX example
 
 ````markdown
 ```rpg-audio
@@ -174,9 +187,7 @@ type: ambience
 loop: true
 file: audio/ambience/forest.mp3
 ```
-````
 
-````markdown
 ```rpg-audio
 id: enter-house
 name: Enter House
@@ -184,9 +195,7 @@ type: sfx
 pauses: ambience
 file: audio/sfx/door-open.mp3
 ```
-````
 
-````markdown
 ```rpg-audio
 id: exit-house
 name: Exit House
@@ -196,55 +205,19 @@ file: audio/sfx/door-close.mp3
 ```
 ````
 
-Play "Outside Ambience", then hit "Enter House" — the ambience pauses (with fade-out if crossfade is on). Later, hit "Exit House" and the ambience picks up right where it left off (with fade-in).
+Play "Outside Ambience", then hit "Enter House" — the ambience pauses. Later, hit "Exit House" and the ambience picks up where it left off.
 
-**Broad targeting with exceptions:**
+### Negation
 
-Useful when a note has its own paired ambient track and wants to clear out any ambient leftovers from elsewhere — but obviously not its own.
-
-````markdown
-```rpg-audio
-id: district-market
-name: Market District Loop
-type: location
-stops: location, ambient, !district-market-crowd
-autoplay: true
-loop: true
-file: audio/locations/market.mp3
-```
-````
-
-````markdown
-```rpg-audio
-id: district-market-crowd
-name: Market Crowd Ambient
-type: ambient
-autoplay: true
-loop: true
-file: audio/ambience/crowd.mp3
-```
-````
-
-When the note is opened, both blocks autoplay. The location block's `stops: location, ambient, !district-market-crowd` kills any other location loop and any leftover ambient from previously-visited notes — but spares the market's own crowd ambient. Tokens prefixed with `!` are exclusions and can refer to a `type:` or `id:`.
-
-## Sidebar
-
-Click the music note icon in the ribbon (or run the **Toggle audio sidebar** command) to open a sidebar panel. The sidebar shows:
-
-- **Global controls** — Fade In All, Fade Out All, and Stop All buttons
-- **Master volume slider** — controls the global volume for all tracks
-- **Tracks grouped by type** — collapsible sections for each type (music, ambience, sfx, etc.)
-- **Per-group fade controls** — fade in or fade out all tracks of a specific type (e.g. fade out all ambience while keeping music playing)
-- **Per-track controls** — play/pause, stop, and volume slider for each track
-- **Playlist status** — shows current position for multi-file tracks (e.g. "Playing 2/5")
+Prefix a token with `!` to exclude it. Example: `stops: ambient, !crowd-ambient` stops every track of type `ambient` except the one with id `crowd-ambient`. With `scope:` available, negation is rarely needed for scene transitions, but it remains useful for the cross-cutting cases above.
 
 ## Tips
 
-- Use `stops: music` on all your music tracks so only one plays at a time — switching scenes is a single click
-- Use `pauses:` and `resumes:` for temporary scene changes (e.g. entering/leaving a building) where you want audio to resume from where it left off
-- Keep ambience and SFX as separate types so you can fade out ambience without killing sound effects
-- Organize your audio folder by type: `audio/music/`, `audio/ambience/`, `audio/sfx/`
-- File paths can be absolute from the vault root (`audio/music/tavern.mp3`) or relative to the configured audio folder (`music/tavern.mp3`)
+- Reach for `scope:` first when you want "playing a track means switching to its scene." Reach for `stops:` / `pauses:` / `resumes:` for explicit one-shot transitions or cross-cutting exceptions.
+- Keep ambience and SFX as separate types so you can fade out ambience without killing sound effects.
+- Organize your audio folder by type: `audio/music/`, `audio/ambience/`, `audio/sfx/`.
+- File paths can be absolute from the vault root (`audio/music/tavern.mp3`) or relative to the configured audio folder (`music/tavern.mp3`).
+- When something behaves unexpectedly, toggle the debug bug icon in the sidebar footer to see why each track is in its current state.
 
 ## Settings
 
@@ -258,7 +231,7 @@ Click the music note icon in the ribbon (or run the **Toggle audio sidebar** com
 
 - **Toggle audio sidebar** — show or hide the audio sidebar panel.
 - **Stop all audio** — stop all currently playing tracks.
-- **Insert audio track** — opens a modal to build and insert an `rpg-audio` code block at the cursor. Lets you set the name, type, files (via fuzzy search), loop, random, autoplay, and advanced options (stops/pauses/resumes) through a form instead of writing YAML by hand.
+- **Insert audio track** — opens a modal to build and insert an `rpg-audio` code block at the cursor.
 
 ## Caveats
 
@@ -267,11 +240,11 @@ Click the music note icon in the ribbon (or run the **Toggle audio sidebar** com
 ## Limitations
 
 - **Mobile/tablet volume sliders** — on mobile and tablet, dragging volume sliders in editing mode may conflict with Obsidian's swipe-to-open-sidebar gesture. Switch to reading mode for smoother slider control.
-- **Local files only** — plays audio from your vault, not streaming services or URLs
-- **No seek/scrubber** — play, pause, and stop only; no jumping to a specific timestamp
-- **No weighted random** — `random: true` gives each track equal probability; no way to bias towards specific tracks
-- **No persistent state** — playback resets when Obsidian restarts
-- **Supported formats** — depends on Electron's audio engine; MP3, OGG, WAV, FLAC, and AAC generally work
+- **Local files only** — plays audio from your vault, not streaming services or URLs.
+- **No seek/scrubber** — play, pause, and stop only; no jumping to a specific timestamp.
+- **No weighted random** — `random: true` gives each track equal probability; no way to bias towards specific tracks.
+- **No persistent state** — playback resets when Obsidian restarts.
+- **Supported formats** — depends on Electron's audio engine; MP3, OGG, WAV, FLAC, and AAC generally work.
 
 ## Installation
 

--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -46,7 +46,6 @@ export class AudioManager extends Events {
 	private gainNodes: Map<string, GainNode> = new Map();
 	private audioContext: AudioContext | null = null;
 	private orphanTimers: Map<string, number> = new Map();
-	private pendingOrphans: Set<string> = new Set();
 	private _masterVolume = 1.0;
 	private _audioFolder = "";
 	private fades = new FadeEngine();
@@ -182,7 +181,6 @@ export class AudioManager extends Events {
 
 	register(def: AudioTrackDef): void {
 		this.clearOrphanTimer(def.id);
-		this.pendingOrphans.delete(def.id);
 
 		const existing = this.tracks.get(def.id);
 		if (existing) {
@@ -203,7 +201,6 @@ export class AudioManager extends Events {
 	}
 
 	unregister(id: string): void {
-		this.pendingOrphans.delete(id);
 		this.fades.cancel(id);
 		this.fadeMultipliers.delete(id);
 		this.playFades.delete(id);
@@ -551,7 +548,8 @@ export class AudioManager extends Events {
 			if (!state) return;
 			if (this.hasLivePlayerElement(id)) return;
 			if (state.playState === PlayState.Playing || state.playState === PlayState.Paused) {
-				this.pendingOrphans.add(id);
+				// Live element gone but track still in use; wait for it to stop, then
+				// cleanupIfOrphaned will pick it up.
 				return;
 			}
 			this.unregister(id);
@@ -570,11 +568,7 @@ export class AudioManager extends Events {
 	}
 
 	private cleanupIfOrphaned(id: string): void {
-		if (!this.pendingOrphans.has(id)) return;
-		if (this.hasLivePlayerElement(id)) {
-			this.pendingOrphans.delete(id);
-			return;
-		}
+		if (this.hasLivePlayerElement(id)) return;
 		this.unregister(id);
 	}
 
@@ -590,7 +584,6 @@ export class AudioManager extends Events {
 		this.fades.destroy();
 		this.fadeMultipliers.clear();
 		this.playFades.clear();
-		this.pendingOrphans.clear();
 		this._activeScope.clear();
 		for (const [, timer] of this.orphanTimers) {
 			window.clearTimeout(timer);

--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -7,6 +7,7 @@ import {
 	EVENT_TRACKS_UPDATED,
 	EVENT_MASTER_VOLUME,
 	EVENT_ALLOW_AUTOPLAY,
+	EVENT_ACTIVE_SCOPE_CHANGED,
 	ORPHAN_CHECK_DELAY_MS,
 } from "./types";
 import { FadeEngine } from "./fade-engine";
@@ -40,6 +41,7 @@ export class AudioManager extends Events {
 	private _playFadeDuration = 0;
 	private _allowAutoplay = false;
 	private playFades: Map<string, "out" | "in"> = new Map();
+	private _activeScope: Set<string> = new Set();
 
 	constructor(app: App) {
 		super();
@@ -113,6 +115,47 @@ export class AudioManager extends Events {
 
 	getAllTracks(): AudioTrackState[] {
 		return Array.from(this.tracks.values());
+	}
+
+	get activeScope(): string[] {
+		return Array.from(this._activeScope);
+	}
+
+	private isScopeSubset(child: string[], parent: Set<string>): boolean {
+		for (const s of child) {
+			if (!parent.has(s)) return false;
+		}
+		return true;
+	}
+
+	/** Returns true if any track was crossfaded out by the transition. */
+	private applyScopeTransition(triggerId: string): boolean {
+		const trigger = this.tracks.get(triggerId);
+		if (!trigger || trigger.def.scope.length === 0) return false;
+
+		const newActive = new Set(trigger.def.scope);
+		const changed =
+			newActive.size !== this._activeScope.size ||
+			!this.isScopeSubset(Array.from(newActive), this._activeScope);
+		this._activeScope = newActive;
+
+		let crossfaded = false;
+		for (const [otherId, other] of this.tracks) {
+			if (otherId === triggerId) continue;
+			if (other.def.scope.length === 0) continue;
+			if (other.playState !== PlayState.Playing) continue;
+			if (this.isScopeSubset(other.def.scope, newActive)) continue;
+
+			if (this._crossfadeDuration > 0) {
+				this.fadeOutAndStop(otherId, this._crossfadeDuration);
+				crossfaded = true;
+			} else {
+				this.stop(otherId);
+			}
+		}
+
+		if (changed) this.trigger(EVENT_ACTIVE_SCOPE_CHANGED, this.activeScope);
+		return crossfaded;
 	}
 
 	getTrack(id: string): AudioTrackState | undefined {
@@ -215,6 +258,10 @@ export class AudioManager extends Events {
 					}
 				}
 			}
+		}
+
+		if (state.def.scope.length > 0) {
+			if (this.applyScopeTransition(id)) crossfading = true;
 		}
 
 		const useCrossfadeIn = crossfading;
@@ -514,6 +561,7 @@ export class AudioManager extends Events {
 		this.fadeMultipliers.clear();
 		this.playFades.clear();
 		this.pendingOrphans.clear();
+		this._activeScope.clear();
 		for (const [, timer] of this.orphanTimers) {
 			window.clearTimeout(timer);
 		}

--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -3,6 +3,9 @@ import {
 	AudioTrackDef,
 	AudioTrackState,
 	PlayState,
+	TrackCause,
+	TrackCauseKind,
+	TrackAction,
 	EVENT_TRACK_CHANGED,
 	EVENT_TRACKS_UPDATED,
 	EVENT_MASTER_VOLUME,
@@ -11,6 +14,17 @@ import {
 	ORPHAN_CHECK_DELAY_MS,
 } from "./types";
 import { FadeEngine } from "./fade-engine";
+
+type CauseInput = {kind: TrackCauseKind; detail?: string};
+
+function buildCause(action: TrackAction, input: CauseInput | undefined): TrackCause {
+	return {
+		action,
+		kind: input?.kind ?? "user",
+		detail: input?.detail,
+		at: Date.now(),
+	};
+}
 
 function matchesDirective(tokens: string[], otherId: string, otherType: string): boolean {
 	let matched = false;
@@ -146,11 +160,15 @@ export class AudioManager extends Events {
 			if (other.playState !== PlayState.Playing) continue;
 			if (this.isScopeSubset(other.def.scope, newActive)) continue;
 
+			const scopeCause: CauseInput = {
+				kind: "scope",
+				detail: `scope changed to {${Array.from(newActive).join(", ")}} by ${triggerId}`,
+			};
 			if (this._crossfadeDuration > 0) {
-				this.fadeOutAndStop(otherId, this._crossfadeDuration);
+				this.fadeOutAndStop(otherId, this._crossfadeDuration, scopeCause);
 				crossfaded = true;
 			} else {
-				this.stop(otherId);
+				this.stop(otherId, scopeCause);
 			}
 		}
 
@@ -179,6 +197,7 @@ export class AudioManager extends Events {
 			volume: 1.0,
 			currentIndex: 0,
 			error: null,
+			lastCause: null,
 		});
 		this.trigger(EVENT_TRACKS_UPDATED);
 	}
@@ -205,7 +224,7 @@ export class AudioManager extends Events {
 		this.trigger(EVENT_TRACKS_UPDATED);
 	}
 
-	async play(id: string, skipPlayFadeIn = false): Promise<void> {
+	async play(id: string, skipPlayFadeIn = false, cause?: CauseInput): Promise<void> {
 		const state = this.tracks.get(id);
 		if (!state) return;
 
@@ -222,11 +241,12 @@ export class AudioManager extends Events {
 		if (state.def.stops.length > 0) {
 			for (const [otherId, other] of this.tracks) {
 				if (otherId !== id && matchesDirective(state.def.stops, otherId, other.def.type) && other.playState === PlayState.Playing) {
+					const directiveCause: CauseInput = {kind: "directive", detail: `stops from ${id}`};
 					if (this._crossfadeDuration > 0) {
-						this.fadeOutAndStop(otherId, this._crossfadeDuration);
+						this.fadeOutAndStop(otherId, this._crossfadeDuration, directiveCause);
 						crossfading = true;
 					} else {
-						this.stop(otherId);
+						this.stop(otherId, directiveCause);
 					}
 				}
 			}
@@ -235,10 +255,11 @@ export class AudioManager extends Events {
 		if (state.def.pauses.length > 0) {
 			for (const [otherId, other] of this.tracks) {
 				if (otherId !== id && matchesDirective(state.def.pauses, otherId, other.def.type) && other.playState === PlayState.Playing) {
+					const directiveCause: CauseInput = {kind: "directive", detail: `pauses from ${id}`};
 					if (this._crossfadeDuration > 0) {
-						this.fadeOutAndPause(otherId, this._crossfadeDuration);
+						this.fadeOutAndPause(otherId, this._crossfadeDuration, directiveCause);
 					} else {
-						this.pause(otherId, false);
+						this.pause(otherId, false, directiveCause);
 					}
 				}
 			}
@@ -247,14 +268,15 @@ export class AudioManager extends Events {
 		if (state.def.resumes.length > 0) {
 			for (const [otherId, other] of this.tracks) {
 				if (otherId !== id && matchesDirective(state.def.resumes, otherId, other.def.type) && other.playState === PlayState.Paused) {
+					const resumeCause: CauseInput = {kind: "directive", detail: `resumes from ${id}`};
 					if (this._crossfadeDuration > 0) {
-						this.play(otherId, true).then(() => {
+						this.play(otherId, true, resumeCause).then(() => {
 							this.fadeIn(otherId, this._crossfadeDuration);
 						}).catch((e) => {
 							console.error(`RPG Audio: resumes fade-in failed for "${otherId}"`, e);
 						});
 					} else {
-						void this.play(otherId);
+						void this.play(otherId, false, resumeCause);
 					}
 				}
 			}
@@ -296,10 +318,12 @@ export class AudioManager extends Events {
 			el.loop = state.def.loop && state.def.files.length === 1;
 		}
 
+		const wasPaused = state.playState === PlayState.Paused;
 		try {
 			await el.play();
 			state.playState = PlayState.Playing;
 			state.error = null;
+			state.lastCause = buildCause(wasPaused ? "resume" : "play", cause);
 			if (useCrossfadeIn) {
 				this.fadeIn(id, this._crossfadeDuration);
 			} else if (usePlayFadeIn) {
@@ -317,7 +341,7 @@ export class AudioManager extends Events {
 		this.trigger(EVENT_TRACK_CHANGED, id);
 	}
 
-	pause(id: string, fromUserToggle = true): void {
+	pause(id: string, fromUserToggle = true, cause?: CauseInput): void {
 		const state = this.tracks.get(id);
 		if (!state) return;
 
@@ -327,20 +351,20 @@ export class AudioManager extends Events {
 			return;
 		}
 		if (fadeMode === "in") {
-			this.startPlayFadeOut(id);
+			this.startPlayFadeOut(id, cause);
 			return;
 		}
 
 		if (state.playState !== PlayState.Playing) return;
 
 		if (this._playFadeDuration > 0) {
-			this.startPlayFadeOut(id);
+			this.startPlayFadeOut(id, cause);
 		} else {
-			this.applyPause(id);
+			this.applyPause(id, cause);
 		}
 	}
 
-	private applyPause(id: string): void {
+	private applyPause(id: string, cause?: CauseInput): void {
 		const state = this.tracks.get(id);
 		if (!state) return;
 
@@ -351,13 +375,14 @@ export class AudioManager extends Events {
 		this.fadeMultipliers.delete(id);
 		this.applyVolume(id);
 		state.playState = PlayState.Paused;
+		state.lastCause = buildCause("pause", cause);
 		this.trigger(EVENT_TRACK_CHANGED, id);
 	}
 
-	private startPlayFadeOut(id: string): void {
+	private startPlayFadeOut(id: string, cause?: CauseInput): void {
 		const current = this.fadeMultipliers.get(id) ?? 1;
 		if (current <= 0) {
-			this.applyPause(id);
+			this.applyPause(id, cause);
 			return;
 		}
 		this.playFades.set(id, "out");
@@ -368,7 +393,7 @@ export class AudioManager extends Events {
 		}).then((completed) => {
 			if (this.playFades.get(id) !== "out") return;
 			if (completed) {
-				this.applyPause(id);
+				this.applyPause(id, cause);
 			} else {
 				this.playFades.delete(id);
 			}
@@ -402,7 +427,7 @@ export class AudioManager extends Events {
 		});
 	}
 
-	stop(id: string): void {
+	stop(id: string, cause?: CauseInput): void {
 		const state = this.tracks.get(id);
 		if (!state) return;
 
@@ -419,6 +444,7 @@ export class AudioManager extends Events {
 		state.playState = PlayState.Stopped;
 		state.currentIndex = 0;
 		state.error = null;
+		state.lastCause = buildCause("stop", cause);
 		this.trigger(EVENT_TRACK_CHANGED, id);
 		this.cleanupIfOrphaned(id);
 	}
@@ -428,11 +454,12 @@ export class AudioManager extends Events {
 		this.fadeMultipliers.clear();
 		this.playFades.clear();
 		for (const [id] of this.tracks) {
-			this.stop(id);
+			this.stop(id, {kind: "user", detail: "stop all"});
 		}
 	}
 
 	fadeOutAll(duration: number): void {
+		const cause: CauseInput = {kind: "system", detail: "fade out all"};
 		for (const [id, state] of this.tracks) {
 			if (state.playState === PlayState.Playing) {
 				const current = this.fadeMultipliers.get(id) ?? 1;
@@ -441,7 +468,7 @@ export class AudioManager extends Events {
 					this.applyVolume(id);
 				}).then((completed) => {
 					if (!completed) return;
-					this.applyPause(id);
+					this.applyPause(id, cause);
 				}).catch((e) => {
 					console.error(`RPG Audio: fade-out failed for "${id}"`, e);
 				});
@@ -450,11 +477,12 @@ export class AudioManager extends Events {
 	}
 
 	fadeInAll(duration: number): void {
+		const cause: CauseInput = {kind: "system", detail: "fade in all"};
 		for (const [id, state] of this.tracks) {
 			if (state.playState === PlayState.Paused) {
 				this.fadeMultipliers.set(id, 0);
 				this.applyVolume(id);
-				this.play(id, true).then(() => {
+				this.play(id, true, cause).then(() => {
 					this.fades.start(id, 0, 1, duration, (value) => {
 						this.fadeMultipliers.set(id, value);
 						this.applyVolume(id);
@@ -469,6 +497,7 @@ export class AudioManager extends Events {
 	}
 
 	fadeOutType(type: string, duration: number): void {
+		const cause: CauseInput = {kind: "system", detail: `fade out ${type}`};
 		for (const [id, state] of this.tracks) {
 			if (state.def.type === type && state.playState === PlayState.Playing) {
 				const current = this.fadeMultipliers.get(id) ?? 1;
@@ -477,7 +506,7 @@ export class AudioManager extends Events {
 					this.applyVolume(id);
 				}).then((completed) => {
 					if (!completed) return;
-					this.applyPause(id);
+					this.applyPause(id, cause);
 				}).catch((e) => {
 					console.error(`RPG Audio: fade-out failed for "${id}"`, e);
 				});
@@ -486,11 +515,12 @@ export class AudioManager extends Events {
 	}
 
 	fadeInType(type: string, duration: number): void {
+		const cause: CauseInput = {kind: "system", detail: `fade in ${type}`};
 		for (const [id, state] of this.tracks) {
 			if (state.def.type === type && state.playState === PlayState.Paused) {
 				this.fadeMultipliers.set(id, 0);
 				this.applyVolume(id);
-				this.play(id, true).then(() => {
+				this.play(id, true, cause).then(() => {
 					this.fades.start(id, 0, 1, duration, (value) => {
 						this.fadeMultipliers.set(id, value);
 						this.applyVolume(id);
@@ -609,6 +639,7 @@ export class AudioManager extends Events {
 			} else {
 				state.playState = PlayState.Stopped;
 				state.currentIndex = 0;
+				state.lastCause = buildCause("stop", {kind: "ended"});
 				this.trigger(EVENT_TRACK_CHANGED, id);
 				this.cleanupIfOrphaned(id);
 			}
@@ -647,12 +678,12 @@ export class AudioManager extends Events {
 		this.trigger(EVENT_TRACK_CHANGED, id);
 	}
 
-	private fadeOutAndPause(id: string, duration: number): void {
-		this.fadeOutThen(id, duration, () => this.pause(id));
+	private fadeOutAndPause(id: string, duration: number, cause?: CauseInput): void {
+		this.fadeOutThen(id, duration, () => this.applyPause(id, cause));
 	}
 
-	private fadeOutAndStop(id: string, duration: number): void {
-		this.fadeOutThen(id, duration, () => this.stop(id));
+	private fadeOutAndStop(id: string, duration: number, cause?: CauseInput): void {
+		this.fadeOutThen(id, duration, () => this.stop(id, cause));
 	}
 
 	private fadeOutThen(id: string, duration: number, onComplete: () => void): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,6 +8,7 @@ export interface RpgAudioSettings {
 	allowAutoplay: boolean;
 	crossfadeDuration: number;
 	playFadeDuration: number;
+	showDebugInfo: boolean;
 }
 
 export const DEFAULT_SETTINGS: RpgAudioSettings = {
@@ -17,6 +18,7 @@ export const DEFAULT_SETTINGS: RpgAudioSettings = {
 	allowAutoplay: false,
 	crossfadeDuration: 2000,
 	playFadeDuration: 0,
+	showDebugInfo: false,
 };
 
 export class RpgAudioSettingTab extends PluginSettingTab {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,12 +18,23 @@ export interface AudioTrackDef {
 	scope: string[];
 }
 
+export type TrackAction = "play" | "pause" | "stop" | "resume";
+export type TrackCauseKind = "user" | "directive" | "scope" | "autoplay" | "system" | "ended";
+
+export interface TrackCause {
+	action: TrackAction;
+	kind: TrackCauseKind;
+	detail?: string;
+	at: number;
+}
+
 export interface AudioTrackState {
 	def: AudioTrackDef;
 	playState: PlayState;
 	volume: number;
 	currentIndex: number;
 	error: string | null;
+	lastCause: TrackCause | null;
 }
 
 export const EVENT_TRACK_CHANGED = "track-changed";

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface AudioTrackDef {
 	stops: string[];
 	resumes: string[];
 	pauses: string[];
+	scope: string[];
 }
 
 export interface AudioTrackState {
@@ -29,6 +30,7 @@ export const EVENT_TRACK_CHANGED = "track-changed";
 export const EVENT_TRACKS_UPDATED = "tracks-updated";
 export const EVENT_MASTER_VOLUME = "master-volume";
 export const EVENT_ALLOW_AUTOPLAY = "allow-autoplay";
+export const EVENT_ACTIVE_SCOPE_CHANGED = "active-scope-changed";
 
 export const SIDEBAR_VIEW_TYPE = "rpg-audio-sidebar";
 

--- a/src/ui/code-block-player.ts
+++ b/src/ui/code-block-player.ts
@@ -124,7 +124,7 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 		this.syncState();
 
 		if (this.def.autoplay && !wasRegistered && this.manager.allowAutoplay) {
-			void this.manager.play(this.def.id);
+			void this.manager.play(this.def.id, false, {kind: "autoplay"});
 		}
 
 		// Obsidian does not call onunload for MarkdownRenderChild inside

--- a/src/ui/code-block-player.ts
+++ b/src/ui/code-block-player.ts
@@ -15,6 +15,7 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 	let stops: string[] = [];
 	let resumes: string[] = [];
 	let pauses: string[] = [];
+	let scope: string[] = [];
 	const files: string[] = [];
 	let inFilesList = false;
 
@@ -69,6 +70,17 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 					pauses = value.split(",").map(s => s.trim()).filter(s => s.length > 0);
 				}
 				break;
+			case "scope":
+				if (value) {
+					const raw = value.split(",").map(s => s.trim()).filter(s => s.length > 0);
+					for (const token of raw) {
+						if (token.includes("/")) {
+							console.warn(`RPG Audio: scope label "${token}" contains "/" which is reserved for future use`);
+						}
+					}
+					scope = Array.from(new Set(raw));
+				}
+				break;
 			case "file":
 				files.push(value);
 				break;
@@ -82,7 +94,7 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 
 	if (!type) type = files.length > 1 ? "playlist" : "sfx";
 
-	return {id, name, type, files, loop, random, autoplay, stops, resumes, pauses};
+	return {id, name, type, files, loop, random, autoplay, stops, resumes, pauses, scope};
 }
 
 export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {

--- a/src/ui/insert-track-modal.ts
+++ b/src/ui/insert-track-modal.ts
@@ -27,6 +27,7 @@ function generateCodeBlock(opts: {
 	stops: string;
 	pauses: string;
 	resumes: string;
+	scope: string;
 }): string {
 	const lines: string[] = [];
 	lines.push(`id: ${opts.id}`);
@@ -35,6 +36,7 @@ function generateCodeBlock(opts: {
 	if (opts.loop) lines.push("loop: true");
 	if (opts.random) lines.push("random: true");
 	if (opts.autoplay) lines.push("autoplay: true");
+	if (opts.scope.trim()) lines.push(`scope: ${opts.scope.trim()}`);
 	if (opts.stops.trim()) lines.push(`stops: ${opts.stops.trim()}`);
 	if (opts.pauses.trim()) lines.push(`pauses: ${opts.pauses.trim()}`);
 	if (opts.resumes.trim()) lines.push(`resumes: ${opts.resumes.trim()}`);
@@ -91,6 +93,7 @@ export class InsertTrackModal extends Modal {
 	private stops = "";
 	private pauses = "";
 	private resumes = "";
+	private scopeInput = "";
 
 	private fileListEl: HTMLElement | null = null;
 	private insertBtn: HTMLButtonElement | null = null;
@@ -199,6 +202,14 @@ export class InsertTrackModal extends Modal {
 			.addToggle(toggle => toggle
 				.setValue(this.autoplay)
 				.onChange(value => { this.autoplay = value; }));
+
+		new Setting(contentEl)
+			.setName("Scope")
+			.setDesc("Comma-separated context labels. Playing a track stops other-scope tracks (e.g. tavern, outdoors)")
+			.addText(text => text
+				// eslint-disable-next-line obsidianmd/ui/sentence-case
+				.setPlaceholder("tavern, outdoors")
+				.onChange(value => { this.scopeInput = value; }));
 
 		// Advanced section
 		contentEl.createEl("details", {}, details => {
@@ -315,6 +326,7 @@ export class InsertTrackModal extends Modal {
 			stops: this.stops,
 			pauses: this.pauses,
 			resumes: this.resumes,
+			scope: this.scopeInput,
 		});
 		this.onInsert(block);
 		this.close();

--- a/src/ui/insert-track-modal.ts
+++ b/src/ui/insert-track-modal.ts
@@ -205,7 +205,7 @@ export class InsertTrackModal extends Modal {
 
 		new Setting(contentEl)
 			.setName("Scope")
-			.setDesc("Comma-separated context labels. Playing a track stops other-scope tracks (e.g. tavern, outdoors)")
+			.setDesc("Comma-separated context labels — playing a track stops other-scope tracks")
 			.addText(text => text
 				// eslint-disable-next-line obsidianmd/ui/sentence-case
 				.setPlaceholder("tavern, outdoors")

--- a/src/ui/sidebar-view.ts
+++ b/src/ui/sidebar-view.ts
@@ -8,21 +8,31 @@ import {
 	EVENT_TRACKS_UPDATED,
 	EVENT_MASTER_VOLUME,
 	EVENT_ALLOW_AUTOPLAY,
+	EVENT_ACTIVE_SCOPE_CHANGED,
 	AudioTrackState,
+	TrackCause,
 	MIN_FADE_DURATION_MS,
 } from "../types";
 import {createPlayerControls, updatePlayPauseButton, PlayerControlsElements} from "./player-controls";
 
+function formatCause(cause: TrackCause): string {
+	const kindLabel = cause.kind === "user" ? "" : ` (${cause.kind})`;
+	const detail = cause.detail ? ` — ${cause.detail}` : "";
+	return `${cause.action}${kindLabel}${detail}`;
+}
+
 export class RpgAudioSidebarView extends ItemView {
 	private plugin: RpgAudioPlugin;
 	private manager: AudioManager;
-	private trackRows: Map<string, {rowEl: HTMLElement; controls: PlayerControlsElements; statusEl: HTMLElement}> = new Map();
+	private trackRows: Map<string, {rowEl: HTMLElement; controls: PlayerControlsElements; statusEl: HTMLElement; debugEl: HTMLElement; scopeEl: HTMLElement}> = new Map();
 	private contentArea: HTMLElement | null = null;
 	private masterSlider: HTMLInputElement | null = null;
 	private autoplayBtn: HTMLElement | null = null;
 	private collapsedGroups: Set<string> = new Set();
 	private globalFadeBtn: HTMLElement | null = null;
 	private typeFadeBtns: Map<string, HTMLElement> = new Map();
+	private debugToggleBtn: HTMLElement | null = null;
+	private activeScopeEl: HTMLElement | null = null;
 
 	constructor(leaf: WorkspaceLeaf, plugin: RpgAudioPlugin) {
 		super(leaf);
@@ -70,6 +80,9 @@ export class RpgAudioSidebarView extends ItemView {
 		this.registerEvent(
 			this.manager.on(EVENT_ALLOW_AUTOPLAY, () => this.updateAutoplayBtn())
 		);
+		this.registerEvent(
+			this.manager.on(EVENT_ACTIVE_SCOPE_CHANGED, () => this.updateActiveScope())
+		);
 	}
 
 	async onClose(): Promise<void> {
@@ -79,6 +92,8 @@ export class RpgAudioSidebarView extends ItemView {
 		this.autoplayBtn = null;
 		this.globalFadeBtn = null;
 		this.typeFadeBtns.clear();
+		this.debugToggleBtn = null;
+		this.activeScopeEl = null;
 	}
 
 	private buildHeader(container: HTMLElement): void {
@@ -129,15 +144,56 @@ export class RpgAudioSidebarView extends ItemView {
 
 	private buildFooter(container: HTMLElement): void {
 		const footer = container.createDiv({cls: "rpg-audio-sidebar-footer"});
-		footer.createSpan({
+
+		this.activeScopeEl = footer.createDiv({cls: "rpg-audio-sidebar-active-scope"});
+		this.updateActiveScope();
+
+		const controls = footer.createDiv({cls: "rpg-audio-sidebar-footer-controls"});
+		controls.createSpan({
 			cls: "rpg-audio-sidebar-version",
 			text: `v${this.plugin.manifest.version}`,
 		});
-		const settingsBtn = footer.createEl("button", {cls: "rpg-audio-btn clickable-icon"});
+
+		this.debugToggleBtn = controls.createEl("button", {cls: "rpg-audio-btn clickable-icon"});
+		this.debugToggleBtn.addEventListener("click", () => void this.toggleDebug());
+		this.updateDebugBtn();
+
+		const settingsBtn = controls.createEl("button", {cls: "rpg-audio-btn clickable-icon"});
 		setIcon(settingsBtn, "settings");
 		// eslint-disable-next-line obsidianmd/ui/sentence-case
 		settingsBtn.setAttribute("aria-label", "Open RPG Audio settings");
 		settingsBtn.addEventListener("click", () => this.openSettings());
+	}
+
+	private updateDebugBtn(): void {
+		if (!this.debugToggleBtn) return;
+		const on = this.plugin.settings.showDebugInfo;
+		setIcon(this.debugToggleBtn, on ? "bug" : "bug-off");
+		this.debugToggleBtn.setAttribute("aria-label", on ? "Debug info on (click to disable)" : "Debug info off (click to enable)");
+		this.debugToggleBtn.toggleClass("is-active", on);
+	}
+
+	private async toggleDebug(): Promise<void> {
+		this.plugin.settings.showDebugInfo = !this.plugin.settings.showDebugInfo;
+		await this.plugin.saveSettings();
+		this.updateDebugBtn();
+		this.updateActiveScope();
+		this.renderAll();
+	}
+
+	private updateActiveScope(): void {
+		if (!this.activeScopeEl) return;
+		const on = this.plugin.settings.showDebugInfo;
+		this.activeScopeEl.empty();
+		if (!on) {
+			this.activeScopeEl.addClass("is-hidden");
+			return;
+		}
+		this.activeScopeEl.removeClass("is-hidden");
+		const scope = this.manager.activeScope;
+		const label = scope.length === 0 ? "(none)" : `{${scope.join(", ")}}`;
+		this.activeScopeEl.createSpan({cls: "rpg-audio-debug-label", text: "Active scope: "});
+		this.activeScopeEl.createSpan({text: label});
 	}
 
 	private renderAll(): void {
@@ -242,7 +298,11 @@ export class RpgAudioSidebarView extends ItemView {
 		const statusEl = row.createDiv({cls: "rpg-audio-status"});
 		this.setStatusText(statusEl, track);
 
-		this.trackRows.set(track.def.id, {rowEl: row, controls, statusEl});
+		const scopeEl = row.createDiv({cls: "rpg-audio-sidebar-track-scope"});
+		const debugEl = row.createDiv({cls: "rpg-audio-sidebar-track-debug"});
+		this.updateDebugEls(scopeEl, debugEl, track);
+
+		this.trackRows.set(track.def.id, {rowEl: row, controls, statusEl, debugEl, scopeEl});
 	}
 
 	private updateTrackRow(id: string): void {
@@ -254,6 +314,33 @@ export class RpgAudioSidebarView extends ItemView {
 		updatePlayPauseButton(row.controls.playPauseBtn, state.playState);
 		row.controls.volumeSlider.value = String(state.volume);
 		this.setStatusText(row.statusEl, state);
+		this.updateDebugEls(row.scopeEl, row.debugEl, state);
+	}
+
+	private updateDebugEls(scopeEl: HTMLElement, debugEl: HTMLElement, track: AudioTrackState): void {
+		const on = this.plugin.settings.showDebugInfo;
+		scopeEl.empty();
+		debugEl.empty();
+		if (!on) {
+			scopeEl.addClass("is-hidden");
+			debugEl.addClass("is-hidden");
+			return;
+		}
+		scopeEl.removeClass("is-hidden");
+		debugEl.removeClass("is-hidden");
+
+		if (track.def.scope.length > 0) {
+			scopeEl.createSpan({cls: "rpg-audio-debug-label", text: "scope: "});
+			scopeEl.createSpan({text: track.def.scope.join(", ")});
+		} else {
+			scopeEl.createSpan({cls: "rpg-audio-debug-muted", text: "no scope"});
+		}
+
+		if (track.lastCause) {
+			debugEl.setText(formatCause(track.lastCause));
+		} else {
+			debugEl.createSpan({cls: "rpg-audio-debug-muted", text: "no events yet"});
+		}
 	}
 
 	private hasPlayingTracks(): boolean {

--- a/styles.css
+++ b/styles.css
@@ -216,14 +216,53 @@
 	padding: 6px 12px;
 	border-top: 1px solid var(--background-modifier-border);
 	display: flex;
-	align-items: center;
-	justify-content: space-between;
+	flex-direction: column;
+	gap: 4px;
 	opacity: 0.6;
 	transition: opacity 0.15s ease;
 }
 
 .rpg-audio-sidebar-footer:hover {
 	opacity: 1;
+}
+
+.rpg-audio-sidebar-footer-controls {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.rpg-audio-sidebar-active-scope {
+	font-size: 0.75em;
+	color: var(--text-muted);
+	font-family: var(--font-monospace);
+}
+
+.rpg-audio-sidebar-active-scope.is-hidden {
+	display: none;
+}
+
+.rpg-audio-sidebar-track-scope,
+.rpg-audio-sidebar-track-debug {
+	font-size: 0.72em;
+	color: var(--text-muted);
+	font-family: var(--font-monospace);
+	margin-top: 2px;
+	line-height: 1.3;
+}
+
+.rpg-audio-sidebar-track-scope.is-hidden,
+.rpg-audio-sidebar-track-debug.is-hidden {
+	display: none;
+}
+
+.rpg-audio-debug-label {
+	color: var(--text-faint);
+}
+
+.rpg-audio-debug-muted {
+	color: var(--text-faint);
+	font-style: italic;
 }
 
 .rpg-audio-sidebar-version {


### PR DESCRIPTION
## Summary

- **`scope:`** — new optional field on `rpg-audio` blocks. Comma-separated context labels. When a scoped track starts playing, the engine updates the active scope set and stops any currently-playing track whose scope is not a subset. Same-scope siblings coexist; no-scope tracks are unaffected by transitions. Stop semantics (not pause) so orphans clean up naturally.
- **Debug overlay** — per-track `lastCause` recorded on every state mutation (action + kind + detail + timestamp). New bug-icon toggle in the sidebar footer reveals each track's scope label and last event, plus the active scope readout.
- **Orphan-cleanup fix** — `cleanupIfOrphaned` no longer gates on a `pendingOrphans` set that could go unpopulated when the orphan timer bailed early on a stale DOM element. Stop All now reliably unregisters tracks whose source note no longer has a rendered player.
- **README restructure** — four common patterns up top (single loop, layered scene, scope transitions, playlists), full field table later, existing directives material moved under "Advanced directives."

## Backwards compatibility

- Tracks without `scope:` behave exactly as today (outside the scope system: neither pause others nor get paused).
- Existing `stops:` / `pauses:` / `resumes:` directives (including `!` negation) fire alongside scope transitions, unchanged.
- New `showDebugInfo` setting defaults to `false`; merged into existing settings on load.
- The orphan-cleanup change only affects the previously-broken case: stopping a track whose source is no longer rendered. Sidebar Stop-on-an-open-note behaviour is unchanged.
- No state migration needed (playback state is not persisted across reloads).

## Test plan

- [x] Reload plugin in a vault with no `scope:` fields anywhere — confirm existing notes behave identically
- [x] `Tests/Scope transitions.md` — all 7 tests pass
- [ ] `Tests/Debug overlay.md` — all 7 tests pass
- [x] `Tests/Transclusion.md` — all 4 tests pass (includes the hover-preview regression test)
- [ ] `Tests/ID and Negation Directives.md` — existing directive behaviour still works
- [ ] Stop All on a sidebar with lingering tracks after closing a note — tracks unregister