### PR TITLE
fix: guard unregister against re-entrant stop → cleanup recursion

### DIFF
--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -46,6 +46,7 @@ export class AudioManager extends Events {
 	private gainNodes: Map<string, GainNode> = new Map();
 	private audioContext: AudioContext | null = null;
 	private orphanTimers: Map<string, number> = new Map();
+	private unregistering: Set<string> = new Set();
 	private _masterVolume = 1.0;
 	private _audioFolder = "";
 	private fades = new FadeEngine();
@@ -201,24 +202,32 @@ export class AudioManager extends Events {
 	}
 
 	unregister(id: string): void {
-		this.fades.cancel(id);
-		this.fadeMultipliers.delete(id);
-		this.playFades.delete(id);
-		this.stop(id);
-		const el = this.audioElements.get(id);
-		if (el) {
-			el.pause();
-			el.removeAttribute("src");
-			el.load();
-			this.audioElements.delete(id);
+		// Break the stop → cleanupIfOrphaned → unregister → stop recursion: the
+		// inner unregister returns here while the outer one finishes the teardown.
+		if (this.unregistering.has(id)) return;
+		this.unregistering.add(id);
+		try {
+			this.fades.cancel(id);
+			this.fadeMultipliers.delete(id);
+			this.playFades.delete(id);
+			this.stop(id);
+			const el = this.audioElements.get(id);
+			if (el) {
+				el.pause();
+				el.removeAttribute("src");
+				el.load();
+				this.audioElements.delete(id);
+			}
+			const gain = this.gainNodes.get(id);
+			if (gain) {
+				gain.disconnect();
+				this.gainNodes.delete(id);
+			}
+			this.tracks.delete(id);
+			this.trigger(EVENT_TRACKS_UPDATED);
+		} finally {
+			this.unregistering.delete(id);
 		}
-		const gain = this.gainNodes.get(id);
-		if (gain) {
-			gain.disconnect();
-			this.gainNodes.delete(id);
-		}
-		this.tracks.delete(id);
-		this.trigger(EVENT_TRACKS_UPDATED);
 	}
 
 	async play(id: string, skipPlayFadeIn = false, cause?: CauseInput): Promise<void> {
@@ -584,6 +593,7 @@ export class AudioManager extends Events {
 		this.fades.destroy();
 		this.fadeMultipliers.clear();
 		this.playFades.clear();
+		this.unregistering.clear();
 		this._activeScope.clear();
 		for (const [, timer] of this.orphanTimers) {
 			window.clearTimeout(timer);


### PR DESCRIPTION
## Summary
- `Stop All` (and stopping any single track whose source note was closed) crashed with `Uncaught RangeError: Maximum call stack size exceeded` via `stop → cleanupIfOrphaned → unregister → stop → …`.
- Commit 6dca47f removed `pendingOrphans`, which had been doing double duty: gating orphan unregister on the 2s observation, **and** acting as a one-shot recursion guard between `stop` and `unregister`. Only the first role was acknowledged.
- Restore the recursion-breaking role with an explicit `unregistering` set. `unregister` early-returns if it sees its own id, so the inner re-entry from `cleanupIfOrphaned` is a no-op while the outer call finishes the teardown. All `EVENT_TRACK_CHANGED` / `EVENT_TRACKS_UPDATED` emissions are preserved.

## Test plan
- [x] Type-check passes (`npm run build`)
- [x] Manual repro confirmed by author:
  1. Start a track from an `rpg-audio` codeblock.
  2. Close the source note (codeblock leaves the DOM); wait ~2s — track lingers in sidebar.
  3. Hit Stop All (or the track's stop button).
  4. Before: `RangeError: Maximum call stack size exceeded`, nothing stops.
  5. After: track stops cleanly and disappears from the sidebar; no console error.
- [x] Stopping a track from the sidebar while its source note is **open** still leaves the track registered (DOM check returns true → no unregister).

🤖 Generated with [Claude Code](https://claude.com/claude-code)