### PR TITLE
feat: add autoplay delay setting to debounce hover-popover triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Prefix a token with `!` to exclude it. Example: `stops: ambient, !crowd-ambient`
 - **Audio folder** — vault-relative folder where your audio files are stored (default: `audio`).
 - **Master volume** — global volume multiplier applied to all tracks.
 - **Auto-open sidebar** — automatically open the sidebar when the plugin loads.
+- **Autoplay delay** — duration in milliseconds to wait before an autoplay track actually starts (default: 0ms / instant). If the track unloads during the delay — for example a hover popover is dismissed before the timer fires — playback is cancelled. Useful when moving the mouse around a map with many marker popovers that would otherwise blast audio on every flicker.
 - **Crossfade duration** — duration in milliseconds of the crossfade between exclusive tracks (default: 2000ms). Set to 0 to disable crossfading and use hard stops.
 - **Play fade duration** — duration in milliseconds of the fade applied when starting, pausing, and resuming a track (default: 0ms / instant). Clicking play during a fade-out reverses into a fade-in (and vice versa).
 

--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -53,6 +53,7 @@ export class AudioManager extends Events {
 	private fadeMultipliers: Map<string, number> = new Map();
 	private _crossfadeDuration = 0;
 	private _playFadeDuration = 0;
+	private _autoplayDelay = 0;
 	private _allowAutoplay = false;
 	private playFades: Map<string, "out" | "in"> = new Map();
 	private _activeScope: Set<string> = new Set();
@@ -103,6 +104,14 @@ export class AudioManager extends Events {
 
 	set playFadeDuration(value: number) {
 		this._playFadeDuration = value;
+	}
+
+	get autoplayDelay(): number {
+		return this._autoplayDelay;
+	}
+
+	set autoplayDelay(value: number) {
+		this._autoplayDelay = value;
 	}
 
 	get allowAutoplay(): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ export default class RpgAudioPlugin extends Plugin {
 		this.audioManager.crossfadeDuration = this.settings.crossfadeDuration;
 		this.audioManager.playFadeDuration = this.settings.playFadeDuration;
 		this.audioManager.allowAutoplay = this.settings.allowAutoplay;
+		this.audioManager.autoplayDelay = this.settings.autoplayDelay;
 
 		this.registerView(SIDEBAR_VIEW_TYPE, (leaf) => new RpgAudioSidebarView(leaf, this));
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ export interface RpgAudioSettings {
 	masterVolume: number;
 	autoOpenSidebar: boolean;
 	allowAutoplay: boolean;
+	autoplayDelay: number;
 	crossfadeDuration: number;
 	playFadeDuration: number;
 	showDebugInfo: boolean;
@@ -16,6 +17,7 @@ export const DEFAULT_SETTINGS: RpgAudioSettings = {
 	masterVolume: 1.0,
 	autoOpenSidebar: true,
 	allowAutoplay: false,
+	autoplayDelay: 0,
 	crossfadeDuration: 2000,
 	playFadeDuration: 0,
 	showDebugInfo: false,
@@ -65,6 +67,19 @@ export class RpgAudioSettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.autoOpenSidebar)
 				.onChange(async (value) => {
 					this.plugin.settings.autoOpenSidebar = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName("Autoplay delay")
+			.setDesc("Delay in milliseconds before an autoplay track starts. If the track unloads during the delay (e.g. a hover popover is dismissed), playback is cancelled. Set to 0 for instant autoplay.")
+			.addSlider(slider => slider
+				.setLimits(0, 2000, 50)
+				.setValue(this.plugin.settings.autoplayDelay)
+				.setDynamicTooltip()
+				.onChange(async (value) => {
+					this.plugin.settings.autoplayDelay = value;
+					this.plugin.audioManager.autoplayDelay = value;
 					await this.plugin.saveSettings();
 				}));
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,7 +72,7 @@ export class RpgAudioSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Autoplay delay")
-			.setDesc("Delay in milliseconds before an autoplay track starts. If the track unloads during the delay (e.g. a hover popover is dismissed), playback is cancelled. Set to 0 for instant autoplay.")
+			.setDesc("Delay before an autoplay track starts. If the track unloads during the delay, for example when a hover popover is dismissed, playback is cancelled. Set to 0 for instant autoplay.")
 			.addSlider(slider => slider
 				.setLimits(0, 2000, 50)
 				.setValue(this.plugin.settings.autoplayDelay)

--- a/src/ui/code-block-player.ts
+++ b/src/ui/code-block-player.ts
@@ -103,6 +103,7 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 	private controls: PlayerControlsElements | null = null;
 	private statusEl: HTMLElement | null = null;
 	private eventRef: (() => void) | null = null;
+	private autoplayTimer: number | null = null;
 
 	constructor(containerEl: HTMLElement, manager: AudioManager, def: AudioTrackDef) {
 		super(containerEl);
@@ -124,7 +125,15 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 		this.syncState();
 
 		if (this.def.autoplay && !wasRegistered && this.manager.allowAutoplay) {
-			void this.manager.play(this.def.id, false, {kind: "autoplay"});
+			const delay = this.manager.autoplayDelay;
+			if (delay > 0) {
+				this.autoplayTimer = window.setTimeout(() => {
+					this.autoplayTimer = null;
+					void this.manager.play(this.def.id, false, {kind: "autoplay"});
+				}, delay);
+			} else {
+				void this.manager.play(this.def.id, false, {kind: "autoplay"});
+			}
 		}
 
 		// Obsidian does not call onunload for MarkdownRenderChild inside
@@ -135,6 +144,10 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 	}
 
 	onunload(): void {
+		if (this.autoplayTimer !== null) {
+			window.clearTimeout(this.autoplayTimer);
+			this.autoplayTimer = null;
+		}
 		if (this.eventRef) {
 			this.eventRef();
 			this.eventRef = null;


### PR DESCRIPTION
## Summary
- New **Autoplay delay** setting (0–2000ms, default 0 = current instant behavior) wired through `AudioManager.autoplayDelay`.
- `RpgAudioCodeBlockPlayer` schedules autoplay via `setTimeout` and stores the handle; `onunload` clears it so a hover popover dismissed before the timer fires never starts the track.
- README "Settings" section documents the new option and the motivating use case (map markers with many popovers).

## Why
Hovering across a note with several `autoplay: true` blocks — especially a map with marker popovers — could blast audio on every flicker. A short delay turns each transient render into a no-op while still letting deliberate hovers/opens trigger playback.

## Test plan
- [ ] With **Autoplay delay = 0**, existing autoplay behavior is unchanged (instant playback on note open / popover).
- [ ] With **Autoplay delay = 500ms**, opening a note with `autoplay: true` plays after ~500ms.
- [ ] With **Autoplay delay = 500ms**, hovering a popover and moving away before 500ms elapses results in **no** playback (popover dismissed → `onunload` cancels the timer).
- [ ] Toggling the setting at runtime takes effect on subsequent renders without a reload.
- [ ] No regression in non-autoplay code paths (manual play/pause/stop still work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)