### PR TITLE
Seek Bar and Region Handles + Full Redesign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# RPG Audio — Obsidian Plugin
+
+An Obsidian community plugin (id: `rpg-audio`) that provides an in-vault audio soundboard for tabletop RPG sessions. Users define audio tracks using fenced `rpg-audio` code blocks in Markdown notes; the plugin renders inline player widgets and a sidebar panel.
+
+## Build & Development
+
+```bash
+npm install
+npm run dev       # esbuild watch mode with sourcemaps
+npm run build     # tsc type-check + esbuild production build
+npm run lint      # eslint
+```
+
+Clone into `.obsidian/plugins/rpg-audio/` for local development.
+
+## Architecture
+
+Zero external runtime dependencies — only the `obsidian` API. TypeScript source bundled via esbuild into `main.js`.
+
+### Source Layout
+
+| File | Responsibility |
+|------|---------------|
+| `src/main.ts` | Plugin lifecycle: loads settings, creates AudioManager, registers code block processor, sidebar view, commands, settings tab |
+| `src/audio-manager.ts` | Core engine: manages tracks, HTMLAudioElements, GainNodes, AudioContext, play/pause/stop/fade, scope transitions, directive matching, orphan cleanup |
+| `src/fade-engine.ts` | Generic `requestAnimationFrame`-based linear value interpolation engine |
+| `src/types.ts` | `PlayState` enum, `AudioTrackDef`/`AudioTrackState`/`TrackCause` interfaces, event constants, timing constants |
+| `src/settings.ts` | `RpgAudioSettings` interface, defaults, settings tab UI |
+| `src/ui/code-block-player.ts` | Parses code block syntax into `AudioTrackDef`, renders inline player widget, handles autoplay |
+| `src/ui/sidebar-view.ts` | Right sidebar: global controls, grouped track list, fade/stop buttons, debug overlay |
+| `src/ui/player-controls.ts` | Shared UI factory for play/pause/stop/volume controls |
+| `src/ui/insert-track-modal.ts` | Modal GUI for building code blocks |
+| `styles.css` | All plugin CSS |
+
+### Audio Pipeline
+
+HTML5 `Audio` element for media playback, routed through Web Audio API for volume control:
+
+```
+HTMLAudioElement → MediaElementAudioSourceNode → GainNode → AudioContext.destination
+```
+
+- One `AudioContext` shared by all tracks (lazy-created)
+- Per-track `GainNode` for volume: `gain.value = trackVolume * masterVolume * fadeMultiplier`
+- `FadeEngine` animates `fadeMultiplier` via `requestAnimationFrame` (linear interpolation)
+
+### Key Data Structures
+
+- `AudioTrackDef` — parsed from code block: id, name, type, files[], loop, random, autoplay, stops[], resumes[], pauses[], scope[]
+- `AudioTrackState` — runtime state: def, playState, volume, currentIndex, error, lastCause
+- Maps keyed by track `id`: `tracks`, `audioElements`, `gainNodes`, `fadeMultipliers`, `playFades`
+
+### Code Block Syntax
+
+Parsed in `parseAudioBlock()` in `code-block-player.ts`. YAML-like key-value pairs. Required: `id`, `name`, at least one `file`/`files` entry.
+
+### Existing Features
+
+- **Multi-track**: simultaneous playback with independent volume
+- **Fading**: crossfade between exclusive tracks, play/pause fade, global/per-type fade (all via FadeEngine)
+- **Looping**: native `el.loop` for single file, manual `ended` handler for playlists
+- **Scope system**: context labels for automatic scene transitions
+- **Directives**: `stops:`, `pauses:`, `resumes:` for inter-track control
+- **Autoplay**: configurable delay, gated by sidebar toggle
+
+### Current Limitations
+
+- No seek/scrubber — only play, pause, stop
+- No time-based region playback (start/end timestamps)
+- No persistent playback state across restarts
+- Local vault files only (no URLs/streaming)
+
+## Lint
+
+ESLint with `typescript-eslint` and `eslint-plugin-obsidianmd`. The obsidian rule `obsidianmd/ui/sentence-case` requires sentence-case text in UI strings (setting descriptions, etc). Avoid periods like "e.g." in setting descriptions — spell out "for example" or restructure.
+
+## Conventions
+
+- No external runtime dependencies — only the `obsidian` API
+- TypeScript strict mode with `noUncheckedIndexedAccess`
+- Events via Obsidian's `Events` mixin (not EventEmitter)
+- CSS class prefix: `rpg-audio-`
+- Track IDs are user-defined slugs (kebab-case by convention)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Turn your session prep notes into a soundboard — ambience, music, and sound effects, all controlled from within Obsidian.
 
-<!-- TODO: screenshot of a note with inline players next to session prep text -->
 ![Inline players in a session note](screenshots/example.png)
 
 ## Features
 
-- **Inline players** — add `rpg-audio` code blocks to any note and get play/pause, stop, and volume controls right next to your encounter text
-- **Sidebar** — a dedicated panel showing all tracks grouped by type, with global and per-group fade controls
+- **Inline players** — add `rpg-audio` code blocks to any note and get play/pause, stop, volume, loop toggle, and a seek bar right next to your encounter text
+- **Seek bar with region handles** — scrub to any position; drag the start/end handles to set a playback region on the fly (the region is highlighted on the bar and loops independently of the rest of the file)
+- **Sidebar** — a dedicated panel showing all tracks grouped by type with colour-coded section headers, per-track seek bar, and global/per-group fade controls
 - **Scene transitions via `scope:`** — label tracks with one or more context tags; playing a scoped track automatically stops tracks from other scopes
 - **Crossfade** — exclusive transitions fade smoothly (configurable duration, or instant)
 - **Playlists** — list multiple files and they play in sequence, with optional looping
@@ -144,9 +144,9 @@ Click the music note icon in the ribbon (or run the **Toggle audio sidebar** com
 
 - **Global controls** — Fade In All, Fade Out All, and Stop All buttons
 - **Master volume slider** — controls the global volume for all tracks
-- **Tracks grouped by type** — collapsible sections for each type (music, ambience, sfx, etc.)
+- **Tracks grouped by type** — collapsible sections colour-coded by type (purple for music, teal for ambience, amber for sfx)
 - **Per-group fade controls** — fade in or fade out all tracks of a specific type
-- **Per-track controls** — play/pause, stop, and volume slider for each track
+- **Per-track controls** — play/pause, stop, loop toggle, volume slider, and a seek bar with region handles for each track
 - **Playlist status** — current position for multi-file tracks (e.g. "Playing 2/5")
 - **Debug toggle** — bug icon in the footer reveals scope labels, last-event info per track, and the active scope set
 
@@ -164,6 +164,10 @@ Click the music note icon in the ribbon (or run the **Toggle audio sidebar** com
 | `stops`     | No   | Comma-separated list of types or track IDs to stop when this track starts playing. Prefix a token with `!` to exclude. See [Advanced directives](#advanced-directives). |
 | `pauses`    | No   | Like `stops`, but paused tracks keep their position and can be resumed later. |
 | `resumes`   | No   | Comma-separated list of types or track IDs to resume when this track starts. Only affects tracks that are currently paused. |
+| `start` | No       | Timestamp (`m:ss` or seconds) where playback begins within the file. Combined with `end`, defines a default region that loops independently. Can be adjusted at runtime by dragging the seek bar handles. |
+| `end`   | No       | Timestamp (`m:ss` or seconds) where the region ends. Playback loops back to `start` when it reaches this point. |
+| `fadein` | No      | Seconds to fade in from silence when the track starts playing. |
+| `fadeout` | No     | Seconds to fade out to silence before the track ends (or region end). |
 | `file`  | \*       | Path to a single audio file, relative to the vault root (e.g. `audio/thunder.mp3`). |
 | `files` | \*       | A list of audio files (one per line, prefixed with `- `). Files play in order as a playlist. |
 
@@ -240,9 +244,8 @@ Prefix a token with `!` to exclude it. Example: `stops: ambient, !crowd-ambient`
 
 ## Limitations
 
-- **Mobile/tablet volume sliders** — on mobile and tablet, dragging volume sliders in editing mode may conflict with Obsidian's swipe-to-open-sidebar gesture. Switch to reading mode for smoother slider control.
+- **Mobile/tablet sliders** — on mobile and tablet, dragging sliders in editing mode may conflict with Obsidian's swipe-to-open-sidebar gesture. Switch to reading mode for smoother control.
 - **Local files only** — plays audio from your vault, not streaming services or URLs.
-- **No seek/scrubber** — play, pause, and stop only; no jumping to a specific timestamp.
 - **No weighted random** — `random: true` gives each track equal probability; no way to bias towards specific tracks.
 - **No persistent state** — playback resets when Obsidian restarts.
 - **Supported formats** — depends on Electron's audio engine; MP3, OGG, WAV, FLAC, and AAC generally work.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "rpg-audio",
 	"name": "RPG Audio",
-	"version": "0.1.37",
+	"version": "0.1.38",
 	"minAppVersion": "1.5.7",
 	"description": "Play audio tracks (one-shots, loops, playlists) for tabletop RPG sessions directly from your notes.",
 	"author": "Knorrli",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "rpg-audio",
 	"name": "RPG Audio",
-	"version": "0.1.38",
+	"version": "0.1.39",
 	"minAppVersion": "1.5.7",
 	"description": "Play audio tracks (one-shots, loops, playlists) for tabletop RPG sessions directly from your notes.",
 	"author": "Knorrli",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rpg-audio",
-	"version": "0.1.38",
+	"version": "0.1.39",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rpg-audio",
-			"version": "0.1.38",
+			"version": "0.1.39",
 			"license": "0-BSD",
 			"dependencies": {
 				"obsidian": "latest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rpg-audio",
-	"version": "0.1.37",
+	"version": "0.1.38",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rpg-audio",
-			"version": "0.1.37",
+			"version": "0.1.38",
 			"license": "0-BSD",
 			"dependencies": {
 				"obsidian": "latest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rpg-audio",
-	"version": "0.1.37",
+	"version": "0.1.38",
 	"description": "Play audio tracks for tabletop RPG sessions directly from your Obsidian notes.",
 	"main": "main.js",
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
 	},
 	"dependencies": {
 		"obsidian": "latest"
+	},
+	"allowScripts": {
+		"esbuild@0.25.5": true
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rpg-audio",
-	"version": "0.1.38",
+	"version": "0.1.39",
 	"description": "Play audio tracks for tabletop RPG sessions directly from your Obsidian notes.",
 	"main": "main.js",
 	"type": "module",

--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -61,6 +61,7 @@ export class AudioManager extends Events {
 	private regionFadeMultipliers: Map<string, number> = new Map();
 	private regionFadeInDone: Set<string> = new Set();
 	private regionOverrides: Map<string, {startTime: number | null; endTime: number | null}> = new Map();
+	private loopOverrides: Map<string, boolean> = new Map();
 
 	constructor(app: App) {
 		super();
@@ -193,6 +194,26 @@ export class AudioManager extends Events {
 		this.regionOverrides.delete(id);
 	}
 
+	getEffectiveLoop(id: string): boolean {
+		if (this.loopOverrides.has(id)) return this.loopOverrides.get(id)!;
+		return this.tracks.get(id)?.def.loop ?? false;
+	}
+
+	setLoopOverride(id: string, value: boolean): void {
+		this.loopOverrides.set(id, value);
+		const el = this.audioElements.get(id);
+		const state = this.tracks.get(id);
+		if (el && state) {
+			const hasReg = this.hasRegion(state.def) || this.regionOverrides.has(id);
+			el.loop = value && state.def.files.length === 1 && !hasReg;
+		}
+		this.trigger(EVENT_TRACK_CHANGED, id);
+	}
+
+	clearLoopOverride(id: string): void {
+		this.loopOverrides.delete(id);
+	}
+
 	private isScopeSubset(child: string[], parent: Set<string>): boolean {
 		for (const s of child) {
 			if (!parent.has(s)) return false;
@@ -270,6 +291,7 @@ export class AudioManager extends Events {
 			this.regionFadeMultipliers.delete(id);
 			this.regionFadeInDone.delete(id);
 			this.regionOverrides.delete(id);
+			this.loopOverrides.delete(id);
 			this.playFades.delete(id);
 			this.stop(id);
 			const el = this.audioElements.get(id);
@@ -383,7 +405,7 @@ export class AudioManager extends Events {
 		const wasPaused = state.playState === PlayState.Paused;
 		if (!wasPaused || !el.src) {
 			el.src = resourceUrl;
-			el.loop = state.def.loop && state.def.files.length === 1 && !this.hasRegion(state.def);
+			el.loop = this.getEffectiveLoop(id) && state.def.files.length === 1 && !this.hasRegion(state.def) && !this.regionOverrides.has(id);
 		}
 
 		// Chromium silently ignores currentTime changes before HAVE_METADATA, so
@@ -518,6 +540,7 @@ export class AudioManager extends Events {
 		this.regionFadeMultipliers.delete(id);
 		this.regionFadeInDone.delete(id);
 		this.regionOverrides.delete(id);
+		this.loopOverrides.delete(id);
 		this.playFades.delete(id);
 
 		const el = this.audioElements.get(id);
@@ -674,6 +697,7 @@ export class AudioManager extends Events {
 		this.regionFadeMultipliers.clear();
 		this.regionFadeInDone.clear();
 		this.regionOverrides.clear();
+		this.loopOverrides.clear();
 		this.playFades.clear();
 		this.unregistering.clear();
 		this._activeScope.clear();
@@ -721,7 +745,7 @@ export class AudioManager extends Events {
 			}
 		}
 
-		if (endTime !== null && def.fadeOutDuration > 0 && !def.loop) {
+		if (endTime !== null && def.fadeOutDuration > 0 && !this.getEffectiveLoop(id)) {
 			const remaining = endTime - currentTime;
 			if (remaining < def.fadeOutDuration) {
 				mult = Math.min(mult, Math.max(0, remaining / def.fadeOutDuration));
@@ -742,7 +766,7 @@ export class AudioManager extends Events {
 			const state = this.tracks.get(id);
 			if (!state) return;
 
-			if (state.def.files.length > 1 && state.def.loop) {
+			if (state.def.files.length > 1 && this.getEffectiveLoop(id)) {
 				if (state.def.random) {
 					let next = Math.floor(Math.random() * state.def.files.length);
 					if (state.def.files.length > 1 && next === state.currentIndex) {
@@ -753,7 +777,7 @@ export class AudioManager extends Events {
 					state.currentIndex = (state.currentIndex + 1) % state.def.files.length;
 				}
 				void this.playCurrentIndex(id);
-			} else if (state.def.files.length === 1 && state.def.loop && (this.hasRegion(state.def) || this.regionOverrides.has(id))) {
+			} else if (state.def.files.length === 1 && this.getEffectiveLoop(id) && (this.hasRegion(state.def) || this.regionOverrides.has(id))) {
 				const region = this.getEffectiveRegion(id);
 				const loopTo = region.startTime ?? 0;
 				el.currentTime = loopTo;
@@ -786,7 +810,7 @@ export class AudioManager extends Events {
 
 			const region = this.getEffectiveRegion(id);
 			if (region.endTime !== null && currentTime >= region.endTime) {
-				if (state.def.loop) {
+				if (this.getEffectiveLoop(id)) {
 					const loopTo = region.startTime ?? 0;
 					el.currentTime = loopTo;
 					const mult = this.computeRegionFade(id, state.def, loopTo);

--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -11,6 +11,7 @@ import {
 	EVENT_MASTER_VOLUME,
 	EVENT_ALLOW_AUTOPLAY,
 	EVENT_ACTIVE_SCOPE_CHANGED,
+	EVENT_TIME_UPDATE,
 	ORPHAN_CHECK_DELAY_MS,
 } from "./types";
 import { FadeEngine } from "./fade-engine";
@@ -58,6 +59,8 @@ export class AudioManager extends Events {
 	private playFades: Map<string, "out" | "in"> = new Map();
 	private _activeScope: Set<string> = new Set();
 	private regionFadeMultipliers: Map<string, number> = new Map();
+	private regionFadeInDone: Set<string> = new Set();
+	private regionOverrides: Map<string, {startTime: number | null; endTime: number | null}> = new Map();
 
 	constructor(app: App) {
 		super();
@@ -145,6 +148,51 @@ export class AudioManager extends Events {
 		return Array.from(this._activeScope);
 	}
 
+	getCurrentTime(id: string): number {
+		const el = this.audioElements.get(id);
+		return el ? el.currentTime : 0;
+	}
+
+	getDuration(id: string): number {
+		const el = this.audioElements.get(id);
+		return el && isFinite(el.duration) ? el.duration : 0;
+	}
+
+	seek(id: string, time: number): void {
+		const el = this.audioElements.get(id);
+		const state = this.tracks.get(id);
+		if (!el || !state) return;
+		const region = this.getEffectiveRegion(id);
+		const lo = region.startTime ?? 0;
+		const hi = region.endTime ?? (isFinite(el.duration) ? el.duration : Infinity);
+		el.currentTime = Math.max(lo, Math.min(hi, time));
+	}
+
+	getEffectiveRegion(id: string): {startTime: number | null; endTime: number | null} {
+		const override = this.regionOverrides.get(id);
+		if (override) return override;
+		const state = this.tracks.get(id);
+		if (!state) return {startTime: null, endTime: null};
+		return {startTime: state.def.startTime, endTime: state.def.endTime};
+	}
+
+	setEffectiveRegion(id: string, startTime: number | null, endTime: number | null): void {
+		this.regionOverrides.set(id, {startTime, endTime});
+		const el = this.audioElements.get(id);
+		const state = this.tracks.get(id);
+		if (el && state && state.playState === PlayState.Playing) {
+			const lo = startTime ?? 0;
+			const hi = endTime ?? (isFinite(el.duration) ? el.duration : Infinity);
+			if (el.currentTime < lo) el.currentTime = lo;
+			if (el.currentTime > hi) el.currentTime = hi;
+		}
+		this.trigger(EVENT_TRACK_CHANGED, id);
+	}
+
+	clearRegionOverride(id: string): void {
+		this.regionOverrides.delete(id);
+	}
+
 	private isScopeSubset(child: string[], parent: Set<string>): boolean {
 		for (const s of child) {
 			if (!parent.has(s)) return false;
@@ -220,6 +268,8 @@ export class AudioManager extends Events {
 			this.fades.cancel(id);
 			this.fadeMultipliers.delete(id);
 			this.regionFadeMultipliers.delete(id);
+			this.regionFadeInDone.delete(id);
+			this.regionOverrides.delete(id);
 			this.playFades.delete(id);
 			this.stop(id);
 			const el = this.audioElements.get(id);
@@ -338,22 +388,23 @@ export class AudioManager extends Events {
 
 		// Chromium silently ignores currentTime changes before HAVE_METADATA, so
 		// wait for loadedmetadata before seeking to the region start.
-		if (!wasPaused && state.def.startTime !== null) {
+		const region = this.getEffectiveRegion(id);
+		if (!wasPaused && region.startTime !== null) {
 			if (el.readyState < HTMLMediaElement.HAVE_METADATA) {
 				await new Promise<void>((resolve) => {
 					el.addEventListener("loadedmetadata", () => resolve(), {once: true});
 					el.addEventListener("error", () => resolve(), {once: true});
 				});
 			}
-			el.currentTime = state.def.startTime;
+			el.currentTime = region.startTime;
 		}
 		try {
 			await el.play();
 			state.playState = PlayState.Playing;
 			state.error = null;
 			state.lastCause = buildCause(wasPaused ? "resume" : "play", cause);
-			if (this.hasRegion(state.def)) {
-				this.regionFadeMultipliers.set(id, this.computeRegionFade(state.def, el.currentTime));
+			if (this.hasRegion(state.def) || this.regionOverrides.has(id)) {
+				this.regionFadeMultipliers.set(id, this.computeRegionFade(id, state.def, el.currentTime));
 			}
 			if (useCrossfadeIn) {
 				this.fadeIn(id, this._crossfadeDuration);
@@ -465,6 +516,8 @@ export class AudioManager extends Events {
 		this.fades.cancel(id);
 		this.fadeMultipliers.delete(id);
 		this.regionFadeMultipliers.delete(id);
+		this.regionFadeInDone.delete(id);
+		this.regionOverrides.delete(id);
 		this.playFades.delete(id);
 
 		const el = this.audioElements.get(id);
@@ -619,6 +672,8 @@ export class AudioManager extends Events {
 		this.fades.destroy();
 		this.fadeMultipliers.clear();
 		this.regionFadeMultipliers.clear();
+		this.regionFadeInDone.clear();
+		this.regionOverrides.clear();
 		this.playFades.clear();
 		this.unregistering.clear();
 		this._activeScope.clear();
@@ -647,16 +702,27 @@ export class AudioManager extends Events {
 		return def.files.length === 1 && (def.startTime !== null || def.endTime !== null);
 	}
 
-	private computeRegionFade(def: AudioTrackDef, currentTime: number): number {
+	private computeRegionFade(id: string, def: AudioTrackDef, currentTime: number): number {
+		const region = this.getEffectiveRegion(id);
+		const startTime = region.startTime;
+		const endTime = region.endTime;
 		let mult = 1;
-		if (def.startTime !== null && def.fadeInDuration > 0) {
-			const elapsed = currentTime - def.startTime;
-			if (elapsed < def.fadeInDuration) {
-				mult = Math.min(mult, Math.max(0, elapsed / def.fadeInDuration));
+
+		if (startTime !== null && def.fadeInDuration > 0) {
+			if (this.regionFadeInDone.has(id)) {
+				// Fade-in already completed; keep multiplier at 1
+			} else {
+				const elapsed = currentTime - startTime;
+				if (elapsed < def.fadeInDuration) {
+					mult = Math.min(mult, Math.max(0, elapsed / def.fadeInDuration));
+				} else {
+					this.regionFadeInDone.add(id);
+				}
 			}
 		}
-		if (def.endTime !== null && def.fadeOutDuration > 0) {
-			const remaining = def.endTime - currentTime;
+
+		if (endTime !== null && def.fadeOutDuration > 0 && !def.loop) {
+			const remaining = endTime - currentTime;
 			if (remaining < def.fadeOutDuration) {
 				mult = Math.min(mult, Math.max(0, remaining / def.fadeOutDuration));
 			}
@@ -687,11 +753,11 @@ export class AudioManager extends Events {
 					state.currentIndex = (state.currentIndex + 1) % state.def.files.length;
 				}
 				void this.playCurrentIndex(id);
-			} else if (state.def.files.length === 1 && state.def.loop && state.def.startTime !== null) {
-				// Native loop is disabled for region tracks; loop back to startTime manually.
-				const loopTo = state.def.startTime;
+			} else if (state.def.files.length === 1 && state.def.loop && (this.hasRegion(state.def) || this.regionOverrides.has(id))) {
+				const region = this.getEffectiveRegion(id);
+				const loopTo = region.startTime ?? 0;
 				el.currentTime = loopTo;
-				const mult = this.computeRegionFade(state.def, loopTo);
+				const mult = this.computeRegionFade(id, state.def, loopTo);
 				this.regionFadeMultipliers.set(id, mult);
 				this.applyVolume(id);
 				void el.play().catch((e) => {
@@ -711,15 +777,19 @@ export class AudioManager extends Events {
 		el.addEventListener("timeupdate", () => {
 			const state = this.tracks.get(id);
 			if (!state || state.playState !== PlayState.Playing) return;
-			if (!this.hasRegion(state.def)) return;
 
 			const currentTime = el.currentTime;
+			const duration = isFinite(el.duration) ? el.duration : 0;
+			this.trigger(EVENT_TIME_UPDATE, id, currentTime, duration);
 
-			if (state.def.endTime !== null && currentTime >= state.def.endTime) {
+			if (!this.hasRegion(state.def) && !this.regionOverrides.has(id)) return;
+
+			const region = this.getEffectiveRegion(id);
+			if (region.endTime !== null && currentTime >= region.endTime) {
 				if (state.def.loop) {
-					const loopTo = state.def.startTime ?? 0;
+					const loopTo = region.startTime ?? 0;
 					el.currentTime = loopTo;
-					const mult = this.computeRegionFade(state.def, loopTo);
+					const mult = this.computeRegionFade(id, state.def, loopTo);
 					this.regionFadeMultipliers.set(id, mult);
 					this.applyVolume(id);
 				} else {
@@ -729,7 +799,7 @@ export class AudioManager extends Events {
 				return;
 			}
 
-			const mult = this.computeRegionFade(state.def, currentTime);
+			const mult = this.computeRegionFade(id, state.def, currentTime);
 			this.regionFadeMultipliers.set(id, mult);
 			this.applyVolume(id);
 		});

--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -57,6 +57,7 @@ export class AudioManager extends Events {
 	private _allowAutoplay = false;
 	private playFades: Map<string, "out" | "in"> = new Map();
 	private _activeScope: Set<string> = new Set();
+	private regionFadeMultipliers: Map<string, number> = new Map();
 
 	constructor(app: App) {
 		super();
@@ -218,6 +219,7 @@ export class AudioManager extends Events {
 		try {
 			this.fades.cancel(id);
 			this.fadeMultipliers.delete(id);
+			this.regionFadeMultipliers.delete(id);
 			this.playFades.delete(id);
 			this.stop(id);
 			const el = this.audioElements.get(id);
@@ -330,7 +332,10 @@ export class AudioManager extends Events {
 
 		if (!(state.playState === PlayState.Paused && el.src)) {
 			el.src = resourceUrl;
-			el.loop = state.def.loop && state.def.files.length === 1;
+			el.loop = state.def.loop && state.def.files.length === 1 && !this.hasRegion(state.def);
+			if (state.def.startTime !== null) {
+				el.currentTime = state.def.startTime;
+			}
 		}
 
 		const wasPaused = state.playState === PlayState.Paused;
@@ -339,6 +344,9 @@ export class AudioManager extends Events {
 			state.playState = PlayState.Playing;
 			state.error = null;
 			state.lastCause = buildCause(wasPaused ? "resume" : "play", cause);
+			if (this.hasRegion(state.def)) {
+				this.regionFadeMultipliers.set(id, this.computeRegionFade(state.def, el.currentTime));
+			}
 			if (useCrossfadeIn) {
 				this.fadeIn(id, this._crossfadeDuration);
 			} else if (usePlayFadeIn) {
@@ -448,6 +456,7 @@ export class AudioManager extends Events {
 
 		this.fades.cancel(id);
 		this.fadeMultipliers.delete(id);
+		this.regionFadeMultipliers.delete(id);
 		this.playFades.delete(id);
 
 		const el = this.audioElements.get(id);
@@ -601,6 +610,7 @@ export class AudioManager extends Events {
 	destroyAll(): void {
 		this.fades.destroy();
 		this.fadeMultipliers.clear();
+		this.regionFadeMultipliers.clear();
 		this.playFades.clear();
 		this.unregistering.clear();
 		this._activeScope.clear();
@@ -625,11 +635,32 @@ export class AudioManager extends Events {
 		this.tracks.clear();
 	}
 
+	private hasRegion(def: AudioTrackDef): boolean {
+		return def.files.length === 1 && (def.startTime !== null || def.endTime !== null);
+	}
+
+	private computeRegionFade(def: AudioTrackDef, currentTime: number): number {
+		let mult = 1;
+		if (def.startTime !== null && def.fadeInDuration > 0) {
+			const elapsed = currentTime - def.startTime;
+			if (elapsed < def.fadeInDuration) {
+				mult = Math.min(mult, Math.max(0, elapsed / def.fadeInDuration));
+			}
+		}
+		if (def.endTime !== null && def.fadeOutDuration > 0) {
+			const remaining = def.endTime - currentTime;
+			if (remaining < def.fadeOutDuration) {
+				mult = Math.min(mult, Math.max(0, remaining / def.fadeOutDuration));
+			}
+		}
+		return mult;
+	}
+
 	private applyVolume(id: string): void {
 		const state = this.tracks.get(id);
 		const gain = this.gainNodes.get(id);
 		if (!state || !gain) return;
-		gain.gain.value = state.volume * this._masterVolume * (this.fadeMultipliers.get(id) ?? 1);
+		gain.gain.value = state.volume * this._masterVolume * (this.fadeMultipliers.get(id) ?? 1) * (this.regionFadeMultipliers.get(id) ?? 1);
 	}
 
 	private setupAudioElement(id: string, el: HTMLAudioElement): void {
@@ -648,6 +679,18 @@ export class AudioManager extends Events {
 					state.currentIndex = (state.currentIndex + 1) % state.def.files.length;
 				}
 				void this.playCurrentIndex(id);
+			} else if (state.def.files.length === 1 && state.def.loop && state.def.startTime !== null) {
+				// Native loop is disabled for region tracks; loop back to startTime manually.
+				const loopTo = state.def.startTime;
+				el.currentTime = loopTo;
+				const mult = this.computeRegionFade(state.def, loopTo);
+				this.regionFadeMultipliers.set(id, mult);
+				this.applyVolume(id);
+				void el.play().catch((e) => {
+					console.error(`RPG Audio: failed to loop region for "${id}"`, e);
+					state.playState = PlayState.Stopped;
+					this.trigger(EVENT_TRACK_CHANGED, id);
+				});
 			} else {
 				state.playState = PlayState.Stopped;
 				state.currentIndex = 0;
@@ -655,6 +698,32 @@ export class AudioManager extends Events {
 				this.trigger(EVENT_TRACK_CHANGED, id);
 				this.cleanupIfOrphaned(id);
 			}
+		});
+
+		el.addEventListener("timeupdate", () => {
+			const state = this.tracks.get(id);
+			if (!state || state.playState !== PlayState.Playing) return;
+			if (!this.hasRegion(state.def)) return;
+
+			const currentTime = el.currentTime;
+
+			if (state.def.endTime !== null && currentTime >= state.def.endTime) {
+				if (state.def.loop) {
+					const loopTo = state.def.startTime ?? 0;
+					el.currentTime = loopTo;
+					const mult = this.computeRegionFade(state.def, loopTo);
+					this.regionFadeMultipliers.set(id, mult);
+					this.applyVolume(id);
+				} else {
+					this.regionFadeMultipliers.delete(id);
+					this.stop(id, {kind: "ended"});
+				}
+				return;
+			}
+
+			const mult = this.computeRegionFade(state.def, currentTime);
+			this.regionFadeMultipliers.set(id, mult);
+			this.applyVolume(id);
 		});
 	}
 

--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -330,15 +330,23 @@ export class AudioManager extends Events {
 			this.setupAudioElement(id, el);
 		}
 
-		if (!(state.playState === PlayState.Paused && el.src)) {
+		const wasPaused = state.playState === PlayState.Paused;
+		if (!wasPaused || !el.src) {
 			el.src = resourceUrl;
 			el.loop = state.def.loop && state.def.files.length === 1 && !this.hasRegion(state.def);
-			if (state.def.startTime !== null) {
-				el.currentTime = state.def.startTime;
-			}
 		}
 
-		const wasPaused = state.playState === PlayState.Paused;
+		// Chromium silently ignores currentTime changes before HAVE_METADATA, so
+		// wait for loadedmetadata before seeking to the region start.
+		if (!wasPaused && state.def.startTime !== null) {
+			if (el.readyState < HTMLMediaElement.HAVE_METADATA) {
+				await new Promise<void>((resolve) => {
+					el.addEventListener("loadedmetadata", () => resolve(), {once: true});
+					el.addEventListener("error", () => resolve(), {once: true});
+				});
+			}
+			el.currentTime = state.def.startTime;
+		}
 		try {
 			await el.play();
 			state.playState = PlayState.Playing;

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ export const EVENT_TRACKS_UPDATED = "tracks-updated";
 export const EVENT_MASTER_VOLUME = "master-volume";
 export const EVENT_ALLOW_AUTOPLAY = "allow-autoplay";
 export const EVENT_ACTIVE_SCOPE_CHANGED = "active-scope-changed";
+export const EVENT_TIME_UPDATE = "time-update";
 
 export const SIDEBAR_VIEW_TYPE = "rpg-audio-sidebar";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,10 @@ export interface AudioTrackDef {
 	resumes: string[];
 	pauses: string[];
 	scope: string[];
+	startTime: number | null;
+	endTime: number | null;
+	fadeInDuration: number;
+	fadeOutDuration: number;
 }
 
 export type TrackAction = "play" | "pause" | "stop" | "resume";

--- a/src/ui/code-block-player.ts
+++ b/src/ui/code-block-player.ts
@@ -3,6 +3,34 @@ import {AudioManager} from "../audio-manager";
 import {AudioTrackDef, PlayState, EVENT_TRACK_CHANGED, DETACH_POLL_INTERVAL_MS} from "../types";
 import {createPlayerControls, updatePlayPauseButton, PlayerControlsElements} from "./player-controls";
 
+function parseTimestamp(str: string): number | null {
+	const parts = str.split(":").map(p => p.trim());
+	if (parts.length === 1) {
+		const s = parseFloat(parts[0] ?? "");
+		return isNaN(s) ? null : s;
+	}
+	if (parts.length === 2) {
+		const m = parseInt(parts[0] ?? "");
+		const s = parseFloat(parts[1] ?? "");
+		if (isNaN(m) || isNaN(s)) return null;
+		return m * 60 + s;
+	}
+	if (parts.length === 3) {
+		const h = parseInt(parts[0] ?? "");
+		const m = parseInt(parts[1] ?? "");
+		const s = parseFloat(parts[2] ?? "");
+		if (isNaN(h) || isNaN(m) || isNaN(s)) return null;
+		return h * 3600 + m * 60 + s;
+	}
+	return null;
+}
+
+export function formatTimestamp(secs: number): string {
+	const m = Math.floor(secs / 60);
+	const s = Math.floor(secs % 60).toString().padStart(2, "0");
+	return `${m}:${s}`;
+}
+
 export function parseAudioBlock(source: string): AudioTrackDef | null {
 	const lines = source.split("\n").map(l => l.trim()).filter(l => l.length > 0);
 
@@ -16,6 +44,10 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 	let resumes: string[] = [];
 	let pauses: string[] = [];
 	let scope: string[] = [];
+	let startTime: number | null = null;
+	let endTime: number | null = null;
+	let fadeInDuration = 0;
+	let fadeOutDuration = 0;
 	const files: string[] = [];
 	let inFilesList = false;
 
@@ -81,6 +113,22 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 					scope = Array.from(new Set(raw));
 				}
 				break;
+			case "start":
+				startTime = parseTimestamp(value);
+				break;
+			case "end":
+				endTime = parseTimestamp(value);
+				break;
+			case "fadein": {
+				const fi = parseFloat(value);
+				if (!isNaN(fi)) fadeInDuration = fi;
+				break;
+			}
+			case "fadeout": {
+				const fo = parseFloat(value);
+				if (!isNaN(fo)) fadeOutDuration = fo;
+				break;
+			}
 			case "file":
 				files.push(value);
 				break;
@@ -94,7 +142,7 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 
 	if (!type) type = files.length > 1 ? "playlist" : "sfx";
 
-	return {id, name, type, files, loop, random, autoplay, stops, resumes, pauses, scope};
+	return {id, name, type, files, loop, random, autoplay, stops, resumes, pauses, scope, startTime, endTime, fadeInDuration, fadeOutDuration};
 }
 
 export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {

--- a/src/ui/code-block-player.ts
+++ b/src/ui/code-block-player.ts
@@ -245,26 +245,25 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 			onStop: () => { this.ensureActive(); this.manager.stop(this.def.id); },
 		});
 
-		// Name + type badge in a header group
-		const header = topRow.createDiv({cls: "rpg-audio-header"});
-		const nameEl = header.createSpan({cls: "rpg-audio-name", text: this.def.name});
+		// Name + type badge
+		const nameEl = topRow.createSpan({cls: "rpg-audio-name", text: this.def.name});
 		nameEl.setAttribute("title", this.def.name);
-		const badge = header.createSpan({cls: "rpg-audio-badge"});
+
+		const badge = topRow.createSpan({cls: "rpg-audio-badge"});
 		badge.setText(this.def.type.toUpperCase());
 		badge.dataset.type = this.def.type.toLowerCase();
 
-		// Right-aligned controls: settings + volume
-		const controls = topRow.createDiv({cls: "rpg-audio-controls"});
+		// Settings buttons (loop toggle + fade indicator) + volume — right-aligned
 		const currentState = this.manager.getTrack(this.def.id);
 		const initialVolume = currentState ? currentState.volume : 1.0;
 
-		this.settingsEl = createSettingsButtons(controls, this.def, (newLoop) => {
+		this.settingsEl = createSettingsButtons(topRow, this.def, (newLoop) => {
 			this.ensureActive();
 			this.manager.setLoopOverride(this.def.id, newLoop);
 		});
 
 		this.volumeSlider = createVolumeControl(
-			controls,
+			topRow,
 			(v) => { this.ensureActive(); this.manager.setTrackVolume(this.def.id, v); },
 			initialVolume,
 		);

--- a/src/ui/code-block-player.ts
+++ b/src/ui/code-block-player.ts
@@ -1,7 +1,7 @@
 import {MarkdownRenderChild, setIcon} from "obsidian";
 import {AudioManager} from "../audio-manager";
-import {AudioTrackDef, PlayState, EVENT_TRACK_CHANGED, DETACH_POLL_INTERVAL_MS} from "../types";
-import {createPlayerControls, updatePlayPauseButton, PlayerControlsElements} from "./player-controls";
+import {AudioTrackDef, PlayState, EVENT_TRACK_CHANGED, EVENT_TIME_UPDATE, DETACH_POLL_INTERVAL_MS} from "../types";
+import {createPlayerControls, updatePlayPauseButton, PlayerControlsElements, createSeekBar, updateSeekBar, SeekBarElements} from "./player-controls";
 
 function parseTimestamp(str: string): number | null {
 	const parts = str.split(":").map(p => p.trim());
@@ -150,7 +150,9 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 	private def: AudioTrackDef;
 	private controls: PlayerControlsElements | null = null;
 	private statusEl: HTMLElement | null = null;
+	private seekBarElements: SeekBarElements | null = null;
 	private eventRef: (() => void) | null = null;
+	private timeUpdateRef: (() => void) | null = null;
 	private autoplayTimer: number | null = null;
 
 	constructor(containerEl: HTMLElement, manager: AudioManager, def: AudioTrackDef) {
@@ -169,6 +171,14 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 		};
 		this.manager.on(EVENT_TRACK_CHANGED, handler);
 		this.eventRef = () => this.manager.off(EVENT_TRACK_CHANGED, handler);
+
+		const timeHandler = (changedId: string, currentTime: number, duration: number) => {
+			if (changedId !== this.def.id || !this.seekBarElements) return;
+			const region = this.manager.getEffectiveRegion(this.def.id);
+			updateSeekBar(this.seekBarElements, currentTime, duration, region);
+		};
+		this.manager.on(EVENT_TIME_UPDATE, timeHandler);
+		this.timeUpdateRef = () => this.manager.off(EVENT_TIME_UPDATE, timeHandler);
 
 		this.syncState();
 
@@ -200,6 +210,10 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 			this.eventRef();
 			this.eventRef = null;
 		}
+		if (this.timeUpdateRef) {
+			this.timeUpdateRef();
+			this.timeUpdateRef = null;
+		}
 		this.manager.scheduleOrphanCheck(this.def.id);
 	}
 
@@ -209,23 +223,64 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 		el.addClass("rpg-audio-player");
 		el.dataset.trackId = this.def.id;
 
-		const header = el.createDiv({cls: "rpg-audio-header"});
+		const topRow = el.createDiv({cls: "rpg-audio-player-top"});
+
+		const header = topRow.createDiv({cls: "rpg-audio-header"});
 		const iconEl = header.createSpan({cls: "rpg-audio-icon"});
 		setIcon(iconEl, this.getTypeIcon());
 		header.createSpan({cls: "rpg-audio-name", text: this.def.name});
 		header.createSpan({cls: "rpg-audio-badge", text: this.def.type});
 
-		this.statusEl = el.createSpan({cls: "rpg-audio-status-inline"});
+		this.statusEl = topRow.createSpan({cls: "rpg-audio-status-inline"});
 
 		const currentState = this.manager.getTrack(this.def.id);
 		const initialVolume = currentState ? currentState.volume : 1.0;
 
-		this.controls = createPlayerControls(el, {
+		this.controls = createPlayerControls(topRow, {
 			onPlay: () => { this.ensureActive(); void this.manager.play(this.def.id); },
 			onPause: () => { this.ensureActive(); this.manager.pause(this.def.id); },
 			onStop: () => { this.ensureActive(); this.manager.stop(this.def.id); },
 			onVolumeChange: (v) => { this.ensureActive(); this.manager.setTrackVolume(this.def.id, v); },
 		}, initialVolume);
+
+		this.buildInfoBadges(el);
+
+		this.seekBarElements = createSeekBar(el, {
+			onSeek: (time) => { this.ensureActive(); this.manager.seek(this.def.id, time); },
+			onRegionChange: (start, end) => { this.ensureActive(); this.manager.setEffectiveRegion(this.def.id, start, end); },
+		});
+	}
+
+	private buildInfoBadges(parent: HTMLElement): void {
+		const badges: {icon: string; text: string}[] = [];
+
+		if (this.def.loop) {
+			badges.push({icon: "repeat", text: "Loop"});
+		}
+
+		if (this.def.startTime !== null || this.def.endTime !== null) {
+			const startLabel = this.def.startTime !== null ? formatTimestamp(this.def.startTime) : "0:00";
+			const endLabel = this.def.endTime !== null ? formatTimestamp(this.def.endTime) : "end";
+			badges.push({icon: "clock", text: `${startLabel} – ${endLabel}`});
+		}
+
+		if (this.def.fadeInDuration > 0 || this.def.fadeOutDuration > 0) {
+			let fadeText = "";
+			if (this.def.fadeInDuration > 0) fadeText += `↑${this.def.fadeInDuration}s`;
+			if (this.def.fadeInDuration > 0 && this.def.fadeOutDuration > 0) fadeText += " ";
+			if (this.def.fadeOutDuration > 0) fadeText += `↓${this.def.fadeOutDuration}s`;
+			badges.push({icon: "volume-1", text: fadeText});
+		}
+
+		if (badges.length === 0) return;
+
+		const infoRow = parent.createDiv({cls: "rpg-audio-info"});
+		for (const badge of badges) {
+			const badgeEl = infoRow.createSpan({cls: "rpg-audio-info-badge"});
+			const badgeIcon = badgeEl.createSpan();
+			setIcon(badgeIcon, badge.icon);
+			badgeEl.createSpan({text: badge.text});
+		}
 	}
 
 	/** Re-register track and event listener if orphaned (e.g. in embedded notes). */
@@ -239,6 +294,15 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 			};
 			this.manager.on(EVENT_TRACK_CHANGED, handler);
 			this.eventRef = () => this.manager.off(EVENT_TRACK_CHANGED, handler);
+		}
+		if (!this.timeUpdateRef) {
+			const timeHandler = (changedId: string, currentTime: number, duration: number) => {
+				if (changedId !== this.def.id || !this.seekBarElements) return;
+				const region = this.manager.getEffectiveRegion(this.def.id);
+				updateSeekBar(this.seekBarElements, currentTime, duration, region);
+			};
+			this.manager.on(EVENT_TIME_UPDATE, timeHandler);
+			this.timeUpdateRef = () => this.manager.off(EVENT_TIME_UPDATE, timeHandler);
 		}
 	}
 
@@ -264,6 +328,13 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 			}
 		}
 		this.statusEl.setText(statusText);
+
+		if (this.seekBarElements) {
+			const currentTime = this.manager.getCurrentTime(this.def.id);
+			const duration = this.manager.getDuration(this.def.id);
+			const region = this.manager.getEffectiveRegion(this.def.id);
+			updateSeekBar(this.seekBarElements, currentTime, duration, region);
+		}
 	}
 
 	private getTypeIcon(): string {

--- a/src/ui/code-block-player.ts
+++ b/src/ui/code-block-player.ts
@@ -245,25 +245,26 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 			onStop: () => { this.ensureActive(); this.manager.stop(this.def.id); },
 		});
 
-		// Name + type badge
-		const nameEl = topRow.createSpan({cls: "rpg-audio-name", text: this.def.name});
+		// Name + type badge in a header group
+		const header = topRow.createDiv({cls: "rpg-audio-header"});
+		const nameEl = header.createSpan({cls: "rpg-audio-name", text: this.def.name});
 		nameEl.setAttribute("title", this.def.name);
-
-		const badge = topRow.createSpan({cls: "rpg-audio-badge"});
+		const badge = header.createSpan({cls: "rpg-audio-badge"});
 		badge.setText(this.def.type.toUpperCase());
 		badge.dataset.type = this.def.type.toLowerCase();
 
-		// Settings buttons (loop toggle + fade indicator) + volume — right-aligned
+		// Right-aligned controls: settings + volume
+		const controls = topRow.createDiv({cls: "rpg-audio-controls"});
 		const currentState = this.manager.getTrack(this.def.id);
 		const initialVolume = currentState ? currentState.volume : 1.0;
 
-		this.settingsEl = createSettingsButtons(topRow, this.def, (newLoop) => {
+		this.settingsEl = createSettingsButtons(controls, this.def, (newLoop) => {
 			this.ensureActive();
 			this.manager.setLoopOverride(this.def.id, newLoop);
 		});
 
 		this.volumeSlider = createVolumeControl(
-			topRow,
+			controls,
 			(v) => { this.ensureActive(); this.manager.setTrackVolume(this.def.id, v); },
 			initialVolume,
 		);

--- a/src/ui/code-block-player.ts
+++ b/src/ui/code-block-player.ts
@@ -1,7 +1,18 @@
 import {MarkdownRenderChild, setIcon} from "obsidian";
 import {AudioManager} from "../audio-manager";
 import {AudioTrackDef, PlayState, EVENT_TRACK_CHANGED, EVENT_TIME_UPDATE, DETACH_POLL_INTERVAL_MS} from "../types";
-import {createPlayerControls, updatePlayPauseButton, PlayerControlsElements, createSeekBar, updateSeekBar, SeekBarElements} from "./player-controls";
+import {
+	createTransportButtons,
+	createVolumeControl,
+	createSettingsButtons,
+	createSeekBar,
+	updatePlayPauseButton,
+	updateSettingsButtons,
+	updateSeekBar,
+	TransportElements,
+	SettingsButtonsElements,
+	SeekBarElements,
+} from "./player-controls";
 
 function parseTimestamp(str: string): number | null {
 	const parts = str.split(":").map(p => p.trim());
@@ -148,8 +159,9 @@ export function parseAudioBlock(source: string): AudioTrackDef | null {
 export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 	private manager: AudioManager;
 	private def: AudioTrackDef;
-	private controls: PlayerControlsElements | null = null;
-	private statusEl: HTMLElement | null = null;
+	private transport: TransportElements | null = null;
+	private volumeSlider: HTMLInputElement | null = null;
+	private settingsEl: SettingsButtonsElements | null = null;
 	private seekBarElements: SeekBarElements | null = null;
 	private eventRef: (() => void) | null = null;
 	private timeUpdateRef: (() => void) | null = null;
@@ -175,7 +187,8 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 		const timeHandler = (changedId: string, currentTime: number, duration: number) => {
 			if (changedId !== this.def.id || !this.seekBarElements) return;
 			const region = this.manager.getEffectiveRegion(this.def.id);
-			updateSeekBar(this.seekBarElements, currentTime, duration, region);
+			// Time updates only fire while playing — pass PlayState.Playing for the gradient
+			updateSeekBar(this.seekBarElements, currentTime, duration, region, PlayState.Playing);
 		};
 		this.manager.on(EVENT_TIME_UPDATE, timeHandler);
 		this.timeUpdateRef = () => this.manager.off(EVENT_TIME_UPDATE, timeHandler);
@@ -225,65 +238,47 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 
 		const topRow = el.createDiv({cls: "rpg-audio-player-top"});
 
-		const header = topRow.createDiv({cls: "rpg-audio-header"});
-		const iconEl = header.createSpan({cls: "rpg-audio-icon"});
-		setIcon(iconEl, this.getTypeIcon());
-		header.createSpan({cls: "rpg-audio-name", text: this.def.name});
-		header.createSpan({cls: "rpg-audio-badge", text: this.def.type});
-
-		this.statusEl = topRow.createSpan({cls: "rpg-audio-status-inline"});
-
-		const currentState = this.manager.getTrack(this.def.id);
-		const initialVolume = currentState ? currentState.volume : 1.0;
-
-		this.controls = createPlayerControls(topRow, {
+		// Transport buttons (play/stop) — leftmost
+		this.transport = createTransportButtons(topRow, {
 			onPlay: () => { this.ensureActive(); void this.manager.play(this.def.id); },
 			onPause: () => { this.ensureActive(); this.manager.pause(this.def.id); },
 			onStop: () => { this.ensureActive(); this.manager.stop(this.def.id); },
-			onVolumeChange: (v) => { this.ensureActive(); this.manager.setTrackVolume(this.def.id, v); },
-		}, initialVolume);
+		});
 
-		this.buildInfoBadges(el);
+		// Name + type badge
+		const nameEl = topRow.createSpan({cls: "rpg-audio-name", text: this.def.name});
+		nameEl.setAttribute("title", this.def.name);
 
+		const badge = topRow.createSpan({cls: "rpg-audio-badge"});
+		badge.setText(this.def.type.toUpperCase());
+		badge.dataset.type = this.def.type.toLowerCase();
+
+		// Settings buttons (loop toggle + fade indicator) + volume — right-aligned
+		const currentState = this.manager.getTrack(this.def.id);
+		const initialVolume = currentState ? currentState.volume : 1.0;
+
+		this.settingsEl = createSettingsButtons(topRow, this.def, (newLoop) => {
+			this.ensureActive();
+			this.manager.setLoopOverride(this.def.id, newLoop);
+		});
+
+		this.volumeSlider = createVolumeControl(
+			topRow,
+			(v) => { this.ensureActive(); this.manager.setTrackVolume(this.def.id, v); },
+			initialVolume,
+		);
+
+		// Seek bar (hidden in stopped state via CSS)
 		this.seekBarElements = createSeekBar(el, {
 			onSeek: (time) => { this.ensureActive(); this.manager.seek(this.def.id, time); },
-			onRegionChange: (start, end) => { this.ensureActive(); this.manager.setEffectiveRegion(this.def.id, start, end); },
+			onRegionChange: (start, end) => {
+				this.ensureActive();
+				this.manager.setEffectiveRegion(this.def.id, start, end);
+			},
 		});
 	}
 
-	private buildInfoBadges(parent: HTMLElement): void {
-		const badges: {icon: string; text: string}[] = [];
-
-		if (this.def.loop) {
-			badges.push({icon: "repeat", text: "Loop"});
-		}
-
-		if (this.def.startTime !== null || this.def.endTime !== null) {
-			const startLabel = this.def.startTime !== null ? formatTimestamp(this.def.startTime) : "0:00";
-			const endLabel = this.def.endTime !== null ? formatTimestamp(this.def.endTime) : "end";
-			badges.push({icon: "clock", text: `${startLabel} – ${endLabel}`});
-		}
-
-		if (this.def.fadeInDuration > 0 || this.def.fadeOutDuration > 0) {
-			let fadeText = "";
-			if (this.def.fadeInDuration > 0) fadeText += `↑${this.def.fadeInDuration}s`;
-			if (this.def.fadeInDuration > 0 && this.def.fadeOutDuration > 0) fadeText += " ";
-			if (this.def.fadeOutDuration > 0) fadeText += `↓${this.def.fadeOutDuration}s`;
-			badges.push({icon: "volume-1", text: fadeText});
-		}
-
-		if (badges.length === 0) return;
-
-		const infoRow = parent.createDiv({cls: "rpg-audio-info"});
-		for (const badge of badges) {
-			const badgeEl = infoRow.createSpan({cls: "rpg-audio-info-badge"});
-			const badgeIcon = badgeEl.createSpan();
-			setIcon(badgeIcon, badge.icon);
-			badgeEl.createSpan({text: badge.text});
-		}
-	}
-
-	/** Re-register track and event listener if orphaned (e.g. in embedded notes). */
+	/** Re-register track and event listeners if orphaned (e.g. in embedded notes). */
 	private ensureActive(): void {
 		if (!this.manager.getTrack(this.def.id)) {
 			this.manager.register(this.def);
@@ -299,7 +294,7 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 			const timeHandler = (changedId: string, currentTime: number, duration: number) => {
 				if (changedId !== this.def.id || !this.seekBarElements) return;
 				const region = this.manager.getEffectiveRegion(this.def.id);
-				updateSeekBar(this.seekBarElements, currentTime, duration, region);
+				updateSeekBar(this.seekBarElements, currentTime, duration, region, PlayState.Playing);
 			};
 			this.manager.on(EVENT_TIME_UPDATE, timeHandler);
 			this.timeUpdateRef = () => this.manager.off(EVENT_TIME_UPDATE, timeHandler);
@@ -308,38 +303,25 @@ export class RpgAudioCodeBlockPlayer extends MarkdownRenderChild {
 
 	private syncState(): void {
 		const state = this.manager.getTrack(this.def.id);
-		if (!state || !this.controls || !this.statusEl) return;
+		if (!state || !this.transport) return;
 
-		updatePlayPauseButton(this.controls.playPauseBtn, state.playState);
-		this.controls.volumeSlider.value = String(state.volume);
+		updatePlayPauseButton(this.transport.playPauseBtn, state.playState);
+		if (this.volumeSlider) this.volumeSlider.value = String(state.volume);
 
 		this.containerEl.toggleClass("is-playing", state.playState === PlayState.Playing);
 		this.containerEl.toggleClass("is-paused", state.playState === PlayState.Paused);
 		this.containerEl.toggleClass("is-stopped", state.playState === PlayState.Stopped);
 
-		let statusText = "";
-		if (state.error) {
-			statusText = state.error;
-			this.statusEl.addClass("rpg-audio-error-text");
-		} else {
-			this.statusEl.removeClass("rpg-audio-error-text");
-			if (state.playState === PlayState.Playing && state.def.files.length > 1) {
-				statusText = `${state.currentIndex + 1}/${state.def.files.length}`;
-			}
+		if (this.settingsEl) {
+			updateSettingsButtons(this.settingsEl, this.manager.getEffectiveLoop(this.def.id));
 		}
-		this.statusEl.setText(statusText);
 
 		if (this.seekBarElements) {
 			const currentTime = this.manager.getCurrentTime(this.def.id);
 			const duration = this.manager.getDuration(this.def.id);
 			const region = this.manager.getEffectiveRegion(this.def.id);
-			updateSeekBar(this.seekBarElements, currentTime, duration, region);
+			updateSeekBar(this.seekBarElements, currentTime, duration, region, state.playState);
 		}
 	}
 
-	private getTypeIcon(): string {
-		if (this.def.files.length > 1) return "list-music";
-		if (this.def.loop) return "repeat";
-		return "music";
-	}
 }

--- a/src/ui/insert-track-modal.ts
+++ b/src/ui/insert-track-modal.ts
@@ -28,6 +28,10 @@ function generateCodeBlock(opts: {
 	pauses: string;
 	resumes: string;
 	scope: string;
+	start: string;
+	end: string;
+	fadein: string;
+	fadeout: string;
 }): string {
 	const lines: string[] = [];
 	lines.push(`id: ${opts.id}`);
@@ -40,6 +44,10 @@ function generateCodeBlock(opts: {
 	if (opts.stops.trim()) lines.push(`stops: ${opts.stops.trim()}`);
 	if (opts.pauses.trim()) lines.push(`pauses: ${opts.pauses.trim()}`);
 	if (opts.resumes.trim()) lines.push(`resumes: ${opts.resumes.trim()}`);
+	if (opts.start.trim()) lines.push(`start: ${opts.start.trim()}`);
+	if (opts.end.trim()) lines.push(`end: ${opts.end.trim()}`);
+	if (opts.fadein.trim()) lines.push(`fadein: ${opts.fadein.trim()}`);
+	if (opts.fadeout.trim()) lines.push(`fadeout: ${opts.fadeout.trim()}`);
 
 	if (opts.files.length === 1) {
 		lines.push(`file: ${opts.files[0]}`);
@@ -94,6 +102,10 @@ export class InsertTrackModal extends Modal {
 	private pauses = "";
 	private resumes = "";
 	private scopeInput = "";
+	private startInput = "";
+	private endInput = "";
+	private fadeinInput = "";
+	private fadeoutInput = "";
 
 	private fileListEl: HTMLElement | null = null;
 	private insertBtn: HTMLButtonElement | null = null;
@@ -238,6 +250,38 @@ export class InsertTrackModal extends Modal {
 					// eslint-disable-next-line obsidianmd/ui/sentence-case
 					.setPlaceholder("ambience")
 					.onChange(value => { this.resumes = value; }));
+
+			new Setting(details)
+				.setName("Start time")
+				.setDesc("Seek to this position on play, for example 0:25 or 1:05:30 (single-file tracks only)")
+				.addText(text => text
+					// eslint-disable-next-line obsidianmd/ui/sentence-case
+					.setPlaceholder("0:25")
+					.onChange(value => { this.startInput = value; }));
+
+			new Setting(details)
+				.setName("End time")
+				.setDesc("Stop or loop at this position, for example 1:33 (single-file tracks only)")
+				.addText(text => text
+					// eslint-disable-next-line obsidianmd/ui/sentence-case
+					.setPlaceholder("1:33")
+					.onChange(value => { this.endInput = value; }));
+
+			new Setting(details)
+				.setName("Fade in duration")
+				.setDesc("Seconds to fade from silence to full volume after the start time, for example 3")
+				.addText(text => text
+					// eslint-disable-next-line obsidianmd/ui/sentence-case
+					.setPlaceholder("3")
+					.onChange(value => { this.fadeinInput = value; }));
+
+			new Setting(details)
+				.setName("Fade out duration")
+				.setDesc("Seconds to fade from full volume to silence before the end time, for example 5")
+				.addText(text => text
+					// eslint-disable-next-line obsidianmd/ui/sentence-case
+					.setPlaceholder("5")
+					.onChange(value => { this.fadeoutInput = value; }));
 		});
 
 		// Insert button
@@ -327,6 +371,10 @@ export class InsertTrackModal extends Modal {
 			pauses: this.pauses,
 			resumes: this.resumes,
 			scope: this.scopeInput,
+			start: this.startInput,
+			end: this.endInput,
+			fadein: this.fadeinInput,
+			fadeout: this.fadeoutInput,
 		});
 		this.onInsert(block);
 		this.close();

--- a/src/ui/player-controls.ts
+++ b/src/ui/player-controls.ts
@@ -62,3 +62,134 @@ export function updatePlayPauseButton(btn: HTMLButtonElement, state: PlayState):
 		btn.setAttribute("aria-label", "Play");
 	}
 }
+
+function formatTs(secs: number): string {
+	const m = Math.floor(secs / 60);
+	const s = Math.floor(secs % 60).toString().padStart(2, "0");
+	return `${m}:${s}`;
+}
+
+export interface SeekBarElements {
+	container: HTMLElement;
+	slider: HTMLInputElement;
+	timeDisplay: HTMLElement;
+	startHandle: HTMLElement;
+	endHandle: HTMLElement;
+}
+
+export interface SeekBarCallbacks {
+	onSeek: (time: number) => void;
+	onRegionChange?: (startTime: number | null, endTime: number | null) => void;
+}
+
+export function createSeekBar(parent: HTMLElement, callbacks: SeekBarCallbacks): SeekBarElements {
+	const container = parent.createDiv({cls: "rpg-audio-seek-container"});
+
+	const slider = container.createEl("input", {
+		cls: "rpg-audio-seek",
+		type: "range",
+	});
+	slider.min = "0";
+	slider.max = "1";
+	slider.step = "0.001";
+	slider.value = "0";
+
+	const timeDisplay = container.createSpan({cls: "rpg-audio-time"});
+
+	const startHandle = container.createDiv({cls: "rpg-audio-region-handle rpg-audio-region-handle-start"});
+	const endHandle = container.createDiv({cls: "rpg-audio-region-handle rpg-audio-region-handle-end"});
+
+	slider.addEventListener("pointerdown", () => { container.dataset.seeking = "1"; });
+	slider.addEventListener("change", () => { delete container.dataset.seeking; });
+	slider.addEventListener("input", () => {
+		const frac = parseFloat(slider.value);
+		const duration = parseFloat(container.dataset.duration ?? "0");
+		callbacks.onSeek(frac * duration);
+	});
+
+	const setupDrag = (handle: HTMLElement, side: "start" | "end") => {
+		handle.addEventListener("pointerdown", (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			handle.setPointerCapture(e.pointerId);
+
+			const onMove = (ev: PointerEvent) => {
+				const rect = slider.getBoundingClientRect();
+				const frac = Math.max(0, Math.min(1, (ev.clientX - rect.left) / rect.width));
+				const duration = parseFloat(container.dataset.duration ?? "0");
+				const time = frac * duration;
+
+				const curStart = container.dataset.regionStart !== undefined ? parseFloat(container.dataset.regionStart) : null;
+				const curEnd = container.dataset.regionEnd !== undefined ? parseFloat(container.dataset.regionEnd) : null;
+
+				if (side === "start") {
+					const maxTime = curEnd !== null ? curEnd - 0.5 : duration;
+					callbacks.onRegionChange?.(Math.max(0, Math.min(maxTime, time)), curEnd);
+				} else {
+					const minTime = curStart !== null ? curStart + 0.5 : 0;
+					callbacks.onRegionChange?.(curStart, Math.max(minTime, Math.min(duration, time)));
+				}
+			};
+
+			const onUp = () => {
+				handle.removeEventListener("pointermove", onMove);
+				handle.removeEventListener("pointerup", onUp);
+			};
+
+			handle.addEventListener("pointermove", onMove);
+			handle.addEventListener("pointerup", onUp);
+		});
+	};
+
+	setupDrag(startHandle, "start");
+	setupDrag(endHandle, "end");
+
+	return {container, slider, timeDisplay, startHandle, endHandle};
+}
+
+export function updateSeekBar(
+	elements: SeekBarElements,
+	currentTime: number,
+	duration: number,
+	region: {startTime: number | null; endTime: number | null},
+): void {
+	elements.container.dataset.duration = String(duration);
+
+	if (region.startTime !== null) {
+		elements.container.dataset.regionStart = String(region.startTime);
+	} else {
+		delete elements.container.dataset.regionStart;
+	}
+	if (region.endTime !== null) {
+		elements.container.dataset.regionEnd = String(region.endTime);
+	} else {
+		delete elements.container.dataset.regionEnd;
+	}
+
+	const denom = Math.max(duration, 0.001);
+	const frac = duration > 0 ? currentTime / duration : 0;
+
+	if (!elements.container.dataset.seeking) {
+		elements.slider.value = String(frac);
+	}
+
+	elements.timeDisplay.setText(`${formatTs(currentTime)} / ${formatTs(duration)}`);
+
+	const regionStart = region.startTime !== null ? region.startTime / denom : 0;
+	const regionEnd = region.endTime !== null ? region.endTime / denom : 1;
+
+	elements.container.style.setProperty("--region-start", `${regionStart * 100}%`);
+	elements.container.style.setProperty("--region-end", `${regionEnd * 100}%`);
+	elements.container.style.setProperty("--seek-progress", `${frac * 100}%`);
+
+	const hasRegion = region.startTime !== null || region.endTime !== null;
+	elements.startHandle.toggleClass("is-hidden", !hasRegion);
+	elements.endHandle.toggleClass("is-hidden", !hasRegion);
+
+	if (hasRegion) {
+		elements.startHandle.style.left = `${regionStart * 100}%`;
+		elements.endHandle.style.left = `${regionEnd * 100}%`;
+		elements.startHandle.setAttribute("title", region.startTime !== null ? formatTs(region.startTime) : "");
+		elements.endHandle.setAttribute("title", region.endTime !== null ? formatTs(region.endTime) : "");
+	}
+}

--- a/src/ui/player-controls.ts
+++ b/src/ui/player-controls.ts
@@ -10,7 +10,6 @@ export interface TransportCallbacks {
 }
 
 export interface TransportElements {
-	container: HTMLElement;
 	playPauseBtn: HTMLButtonElement;
 	stopBtn: HTMLButtonElement;
 }
@@ -19,15 +18,13 @@ export function createTransportButtons(
 	parent: HTMLElement,
 	callbacks: TransportCallbacks,
 ): TransportElements {
-	const container = parent.createDiv({cls: "rpg-audio-transport"});
-
-	const playPauseBtn = container.createEl("button", {
+	const playPauseBtn = parent.createEl("button", {
 		cls: "rpg-audio-btn rpg-audio-play-btn clickable-icon",
 	});
 	setIcon(playPauseBtn, "play");
 	playPauseBtn.setAttribute("aria-label", "Play");
 
-	const stopBtn = container.createEl("button", {
+	const stopBtn = parent.createEl("button", {
 		cls: "rpg-audio-btn rpg-audio-stop-btn clickable-icon",
 	});
 	setIcon(stopBtn, "square");
@@ -42,7 +39,7 @@ export function createTransportButtons(
 	});
 	stopBtn.addEventListener("click", () => callbacks.onStop());
 
-	return {container, playPauseBtn, stopBtn};
+	return {playPauseBtn, stopBtn};
 }
 
 export function updatePlayPauseButton(btn: HTMLButtonElement, state: PlayState): void {
@@ -106,14 +103,12 @@ export function createSettingsButtons(
 	setIcon(loopBtn, "repeat");
 	loopBtn.toggleClass("is-active", def.loop);
 	loopBtn.setAttribute("aria-label", def.loop ? "Loop: on" : "Loop: off");
-	loopBtn.setAttribute("title", def.loop ? "Loop: on" : "Loop: off");
 
 	if (onLoopToggle) {
 		loopBtn.addEventListener("click", () => {
 			const newValue = !loopBtn.hasClass("is-active");
 			loopBtn.toggleClass("is-active", newValue);
 			loopBtn.setAttribute("aria-label", newValue ? "Loop: on" : "Loop: off");
-			loopBtn.setAttribute("title", newValue ? "Loop: on" : "Loop: off");
 			onLoopToggle(newValue);
 		});
 	}
@@ -126,7 +121,6 @@ export function createSettingsButtons(
 		if (def.fadeInDuration > 0) parts.push(`Fade in: ${def.fadeInDuration}s`);
 		if (def.fadeOutDuration > 0) parts.push(`Fade out: ${def.fadeOutDuration}s`);
 		const label = parts.join(" / ");
-		fadeEl.setAttribute("title", label);
 		fadeEl.setAttribute("aria-label", label);
 	}
 
@@ -136,7 +130,6 @@ export function createSettingsButtons(
 export function updateSettingsButtons(elements: SettingsButtonsElements, loopOn: boolean): void {
 	elements.loopBtn.toggleClass("is-active", loopOn);
 	elements.loopBtn.setAttribute("aria-label", loopOn ? "Loop: on" : "Loop: off");
-	elements.loopBtn.setAttribute("title", loopOn ? "Loop: on" : "Loop: off");
 }
 
 // ─── Seek bar ─────────────────────────────────────────────────────────────────
@@ -250,7 +243,7 @@ export function createSeekBar(parent: HTMLElement, callbacks: SeekBarCallbacks):
 			handle.setPointerCapture(e.pointerId);
 
 			const onMove = (ev: PointerEvent) => {
-				const rect = slider.getBoundingClientRect();
+				const rect = track.getBoundingClientRect();
 				const frac = Math.max(0, Math.min(1, (ev.clientX - rect.left) / rect.width));
 				const duration = parseFloat(container.dataset.duration ?? "0");
 				const time = frac * duration;

--- a/src/ui/player-controls.ts
+++ b/src/ui/player-controls.ts
@@ -1,66 +1,158 @@
 import {setIcon} from "obsidian";
 import {PlayState} from "../types";
 
-export interface PlayerControlsCallbacks {
+// ─── Transport buttons ────────────────────────────────────────────────────────
+
+export interface TransportCallbacks {
 	onPlay: () => void;
 	onPause: () => void;
 	onStop: () => void;
-	onVolumeChange: (volume: number) => void;
 }
 
-export interface PlayerControlsElements {
-	container: HTMLElement;
+export interface TransportElements {
 	playPauseBtn: HTMLButtonElement;
 	stopBtn: HTMLButtonElement;
-	volumeSlider: HTMLInputElement;
 }
 
-export function createPlayerControls(
+export function createTransportButtons(
 	parent: HTMLElement,
-	callbacks: PlayerControlsCallbacks,
-	initialVolume = 1.0,
-): PlayerControlsElements {
-	const container = parent.createDiv({cls: "rpg-audio-controls"});
-
-	const playPauseBtn = container.createEl("button", {cls: "rpg-audio-btn rpg-audio-play-btn clickable-icon"});
-	setIcon(playPauseBtn, "play");
-
-	const stopBtn = container.createEl("button", {cls: "rpg-audio-btn rpg-audio-stop-btn clickable-icon"});
-	setIcon(stopBtn, "square");
-
-	const volumeSlider = container.createEl("input", {
-		cls: "rpg-audio-volume",
-		type: "range",
+	callbacks: TransportCallbacks,
+): TransportElements {
+	const playPauseBtn = parent.createEl("button", {
+		cls: "rpg-audio-btn rpg-audio-play-btn clickable-icon",
 	});
-	volumeSlider.min = "0";
-	volumeSlider.max = "1";
-	volumeSlider.step = "0.01";
-	volumeSlider.value = String(initialVolume);
+	setIcon(playPauseBtn, "play");
+	playPauseBtn.setAttribute("aria-label", "Play");
+
+	const stopBtn = parent.createEl("button", {
+		cls: "rpg-audio-btn rpg-audio-stop-btn clickable-icon",
+	});
+	setIcon(stopBtn, "square");
+	stopBtn.setAttribute("aria-label", "Stop");
 
 	playPauseBtn.addEventListener("click", () => {
-		const isPlaying = playPauseBtn.dataset["state"] === PlayState.Playing;
-		if (isPlaying) {
+		if (playPauseBtn.dataset["state"] === PlayState.Playing) {
 			callbacks.onPause();
 		} else {
 			callbacks.onPlay();
 		}
 	});
-
 	stopBtn.addEventListener("click", () => callbacks.onStop());
-	volumeSlider.addEventListener("input", () => callbacks.onVolumeChange(parseFloat(volumeSlider.value)));
 
-	return {container, playPauseBtn, stopBtn, volumeSlider};
+	return {playPauseBtn, stopBtn};
 }
 
 export function updatePlayPauseButton(btn: HTMLButtonElement, state: PlayState): void {
 	btn.dataset["state"] = state;
+	btn.removeClass("is-state-playing");
+	btn.removeClass("is-state-paused");
+	btn.removeClass("is-state-stopped");
+
 	if (state === PlayState.Playing) {
 		setIcon(btn, "pause");
 		btn.setAttribute("aria-label", "Pause");
+		btn.addClass("is-state-playing");
+	} else if (state === PlayState.Paused) {
+		setIcon(btn, "play");
+		btn.setAttribute("aria-label", "Play");
+		btn.addClass("is-state-paused");
 	} else {
 		setIcon(btn, "play");
 		btn.setAttribute("aria-label", "Play");
+		btn.addClass("is-state-stopped");
 	}
+}
+
+// ─── Volume control ───────────────────────────────────────────────────────────
+
+export function createVolumeControl(
+	parent: HTMLElement,
+	onChange: (value: number) => void,
+	initial = 1.0,
+): HTMLInputElement {
+	const wrapper = parent.createDiv({cls: "rpg-audio-vol-wrapper"});
+	const volIcon = wrapper.createSpan({cls: "rpg-audio-vol-icon"});
+	setIcon(volIcon, "volume-2");
+
+	const slider = wrapper.createEl("input", {cls: "rpg-audio-volume", type: "range"});
+	slider.min = "0";
+	slider.max = "1";
+	slider.step = "0.01";
+	slider.value = String(initial);
+	slider.addEventListener("input", () => onChange(parseFloat(slider.value)));
+
+	return slider;
+}
+
+// ─── Settings buttons (loop toggle + fade indicator) ─────────────────────────
+
+export interface SettingsButtonsElements {
+	container: HTMLElement;
+	loopBtn: HTMLButtonElement;
+	fadeEl: HTMLElement | null;
+}
+
+export function createSettingsButtons(
+	parent: HTMLElement,
+	def: {loop: boolean; fadeInDuration: number; fadeOutDuration: number},
+	onLoopToggle?: (newValue: boolean) => void,
+): SettingsButtonsElements {
+	const container = parent.createDiv({cls: "rpg-audio-settings-buttons"});
+
+	const loopBtn = container.createEl("button", {cls: "rpg-audio-settings-btn clickable-icon"});
+	setIcon(loopBtn, "repeat");
+	loopBtn.toggleClass("is-active", def.loop);
+	loopBtn.setAttribute("aria-label", def.loop ? "Loop: on" : "Loop: off");
+	loopBtn.setAttribute("title", def.loop ? "Loop: on" : "Loop: off");
+
+	if (onLoopToggle) {
+		loopBtn.addEventListener("click", () => {
+			const newValue = !loopBtn.hasClass("is-active");
+			loopBtn.toggleClass("is-active", newValue);
+			loopBtn.setAttribute("aria-label", newValue ? "Loop: on" : "Loop: off");
+			loopBtn.setAttribute("title", newValue ? "Loop: on" : "Loop: off");
+			onLoopToggle(newValue);
+		});
+	}
+
+	let fadeEl: HTMLElement | null = null;
+	if (def.fadeInDuration > 0 || def.fadeOutDuration > 0) {
+		fadeEl = container.createSpan({cls: "rpg-audio-settings-btn is-active"});
+		setIcon(fadeEl, "activity");
+		const parts: string[] = [];
+		if (def.fadeInDuration > 0) parts.push(`Fade in: ${def.fadeInDuration}s`);
+		if (def.fadeOutDuration > 0) parts.push(`Fade out: ${def.fadeOutDuration}s`);
+		const label = parts.join(" / ");
+		fadeEl.setAttribute("title", label);
+		fadeEl.setAttribute("aria-label", label);
+	}
+
+	return {container, loopBtn, fadeEl};
+}
+
+export function updateSettingsButtons(elements: SettingsButtonsElements, loopOn: boolean): void {
+	elements.loopBtn.toggleClass("is-active", loopOn);
+	elements.loopBtn.setAttribute("aria-label", loopOn ? "Loop: on" : "Loop: off");
+	elements.loopBtn.setAttribute("title", loopOn ? "Loop: on" : "Loop: off");
+}
+
+// ─── Seek bar ─────────────────────────────────────────────────────────────────
+
+export interface SeekBarElements {
+	wrapper: HTMLElement;
+	container: HTMLElement;
+	track: HTMLElement;
+	slider: HTMLInputElement;
+	startHandle: HTMLElement;
+	endHandle: HTMLElement;
+	timeLeft: HTMLElement;
+	timeCenter: HTMLElement;
+	timeRight: HTMLElement;
+}
+
+export interface SeekBarCallbacks {
+	onSeek: (time: number) => void;
+	onRegionChange?: (startTime: number | null, endTime: number | null) => void;
 }
 
 function formatTs(secs: number): string {
@@ -69,38 +161,79 @@ function formatTs(secs: number): string {
 	return `${m}:${s}`;
 }
 
-export interface SeekBarElements {
-	container: HTMLElement;
-	slider: HTMLInputElement;
-	timeDisplay: HTMLElement;
-	startHandle: HTMLElement;
-	endHandle: HTMLElement;
-}
+function buildSeekBackground(
+	prog: number,
+	rs: number,
+	re: number,
+	hasRegion: boolean,
+	paused: boolean,
+): string {
+	const a0 = paused ? "rgba(80,60,140,0.4)" : "#6b4fa8";
+	const a1 = paused ? "rgba(100,79,168,0.4)" : "#7c5cbf";
+	const dim = "rgba(124,92,191,0.15)";
+	const hatch = "repeating-linear-gradient(90deg, rgba(255,255,255,.03) 0px, rgba(255,255,255,.03) 2px, transparent 2px, transparent 4px)";
+	const base = "rgba(255,255,255,0.05)";
+	const p = (n: number) => `${(n * 100).toFixed(2)}%`;
 
-export interface SeekBarCallbacks {
-	onSeek: (time: number) => void;
-	onRegionChange?: (startTime: number | null, endTime: number | null) => void;
+	if (!hasRegion) {
+		const main = `linear-gradient(90deg, ${a0} 0%, ${a1} ${p(prog)}, ${dim} ${p(prog)}, ${dim} 100%)`;
+		return `${main}, ${base}`;
+	}
+
+	// Clamp progress to region bounds
+	const ep = Math.max(rs, Math.min(re, prog));
+
+	// Build 4-zone gradient: [out-of-region | played | unplayed-in-region | out-of-region]
+	// Zero-width zones (when boundaries coincide) are handled gracefully by CSS.
+	const stops = [
+		`transparent ${p(0)}`,
+		`transparent ${p(rs)}`,
+		`${a0} ${p(rs)}`,
+		`${a1} ${p(ep)}`,
+		`${dim} ${p(ep)}`,
+		`${dim} ${p(re)}`,
+		`transparent ${p(re)}`,
+		`transparent ${p(1)}`,
+	];
+
+	const main = `linear-gradient(90deg, ${stops.join(", ")})`;
+	return `${main}, ${hatch}, ${base}`;
 }
 
 export function createSeekBar(parent: HTMLElement, callbacks: SeekBarCallbacks): SeekBarElements {
-	const container = parent.createDiv({cls: "rpg-audio-seek-container"});
+	const wrapper = parent.createDiv({cls: "rpg-audio-seek-wrapper"});
 
-	const slider = container.createEl("input", {
-		cls: "rpg-audio-seek",
-		type: "range",
-	});
+	const container = wrapper.createDiv({cls: "rpg-audio-seek-container"});
+	const track = container.createDiv({cls: "rpg-audio-seek-track"});
+
+	const slider = container.createEl("input", {cls: "rpg-audio-seek", type: "range"});
 	slider.min = "0";
 	slider.max = "1";
 	slider.step = "0.001";
 	slider.value = "0";
 
-	const timeDisplay = container.createSpan({cls: "rpg-audio-time"});
+	const startHandle = container.createDiv({
+		cls: "rpg-audio-region-handle rpg-audio-region-handle-start is-dormant",
+	});
+	const endHandle = container.createDiv({
+		cls: "rpg-audio-region-handle rpg-audio-region-handle-end is-dormant",
+	});
 
-	const startHandle = container.createDiv({cls: "rpg-audio-region-handle rpg-audio-region-handle-start"});
-	const endHandle = container.createDiv({cls: "rpg-audio-region-handle rpg-audio-region-handle-end"});
+	const timeRow = wrapper.createDiv({cls: "rpg-audio-time-row"});
+	const timeLeft = timeRow.createSpan({cls: "rpg-audio-time-left"});
+	const timeCenter = timeRow.createSpan({cls: "rpg-audio-time-center"});
+	const timeRight = timeRow.createSpan({cls: "rpg-audio-time-right"});
 
-	slider.addEventListener("pointerdown", () => { container.dataset.seeking = "1"; });
-	slider.addEventListener("change", () => { delete container.dataset.seeking; });
+	// Initial dormant handle positions
+	startHandle.style.left = "0%";
+	endHandle.style.left = "100%";
+
+	slider.addEventListener("pointerdown", () => {
+		container.dataset.seeking = "1";
+	});
+	slider.addEventListener("change", () => {
+		delete container.dataset.seeking;
+	});
 	slider.addEventListener("input", () => {
 		const frac = parseFloat(slider.value);
 		const duration = parseFloat(container.dataset.duration ?? "0");
@@ -119,8 +252,12 @@ export function createSeekBar(parent: HTMLElement, callbacks: SeekBarCallbacks):
 				const duration = parseFloat(container.dataset.duration ?? "0");
 				const time = frac * duration;
 
-				const curStart = container.dataset.regionStart !== undefined ? parseFloat(container.dataset.regionStart) : null;
-				const curEnd = container.dataset.regionEnd !== undefined ? parseFloat(container.dataset.regionEnd) : null;
+				const curStart = container.dataset.regionStart !== undefined
+					? parseFloat(container.dataset.regionStart)
+					: null;
+				const curEnd = container.dataset.regionEnd !== undefined
+					? parseFloat(container.dataset.regionEnd)
+					: null;
 
 				if (side === "start") {
 					const maxTime = curEnd !== null ? curEnd - 0.5 : duration;
@@ -144,7 +281,7 @@ export function createSeekBar(parent: HTMLElement, callbacks: SeekBarCallbacks):
 	setupDrag(startHandle, "start");
 	setupDrag(endHandle, "end");
 
-	return {container, slider, timeDisplay, startHandle, endHandle};
+	return {wrapper, container, track, slider, startHandle, endHandle, timeLeft, timeCenter, timeRight};
 }
 
 export function updateSeekBar(
@@ -152,6 +289,7 @@ export function updateSeekBar(
 	currentTime: number,
 	duration: number,
 	region: {startTime: number | null; endTime: number | null},
+	playState?: PlayState,
 ): void {
 	elements.container.dataset.duration = String(duration);
 
@@ -167,29 +305,51 @@ export function updateSeekBar(
 	}
 
 	const denom = Math.max(duration, 0.001);
-	const frac = duration > 0 ? currentTime / duration : 0;
+	const prog = duration > 0 ? currentTime / denom : 0;
 
 	if (!elements.container.dataset.seeking) {
-		elements.slider.value = String(frac);
+		elements.slider.value = String(prog);
 	}
 
-	elements.timeDisplay.setText(`${formatTs(currentTime)} / ${formatTs(duration)}`);
-
-	const regionStart = region.startTime !== null ? region.startTime / denom : 0;
-	const regionEnd = region.endTime !== null ? region.endTime / denom : 1;
-
-	elements.container.style.setProperty("--region-start", `${regionStart * 100}%`);
-	elements.container.style.setProperty("--region-end", `${regionEnd * 100}%`);
-	elements.container.style.setProperty("--seek-progress", `${frac * 100}%`);
-
 	const hasRegion = region.startTime !== null || region.endTime !== null;
-	elements.startHandle.toggleClass("is-hidden", !hasRegion);
-	elements.endHandle.toggleClass("is-hidden", !hasRegion);
+	const rs = region.startTime !== null ? region.startTime / denom : 0;
+	const re = region.endTime !== null ? region.endTime / denom : 1;
+	const paused = playState === PlayState.Paused;
 
-	if (hasRegion) {
-		elements.startHandle.style.left = `${regionStart * 100}%`;
-		elements.endHandle.style.left = `${regionEnd * 100}%`;
-		elements.startHandle.setAttribute("title", region.startTime !== null ? formatTs(region.startTime) : "");
-		elements.endHandle.setAttribute("title", region.endTime !== null ? formatTs(region.endTime) : "");
+	// Update visual track gradient
+	elements.track.style.background = buildSeekBackground(prog, rs, re, hasRegion, paused);
+
+	// Handles: dormant (parked at edges, muted) or active (at region bounds, glowing)
+	const dormant = !hasRegion;
+	elements.startHandle.toggleClass("is-dormant", dormant);
+	elements.endHandle.toggleClass("is-dormant", dormant);
+	if (dormant) {
+		elements.startHandle.style.left = "0%";
+		elements.endHandle.style.left = "100%";
+	} else {
+		elements.startHandle.style.left = `${rs * 100}%`;
+		elements.endHandle.style.left = `${re * 100}%`;
+	}
+	elements.startHandle.setAttribute(
+		"title",
+		region.startTime !== null ? formatTs(region.startTime) : "",
+	);
+	elements.endHandle.setAttribute(
+		"title",
+		region.endTime !== null ? formatTs(region.endTime) : "",
+	);
+
+	// Time labels
+	elements.timeLeft.setText(formatTs(currentTime));
+	elements.timeRight.setText(formatTs(duration));
+
+	if (paused) {
+		elements.timeCenter.setText("paused");
+	} else if (hasRegion) {
+		const startLabel = region.startTime !== null ? formatTs(region.startTime) : "0:00";
+		const endLabel = region.endTime !== null ? formatTs(region.endTime) : formatTs(duration);
+		elements.timeCenter.setText(`region ${startLabel} – ${endLabel}`);
+	} else {
+		elements.timeCenter.setText("");
 	}
 }

--- a/src/ui/player-controls.ts
+++ b/src/ui/player-controls.ts
@@ -10,6 +10,7 @@ export interface TransportCallbacks {
 }
 
 export interface TransportElements {
+	container: HTMLElement;
 	playPauseBtn: HTMLButtonElement;
 	stopBtn: HTMLButtonElement;
 }
@@ -18,13 +19,15 @@ export function createTransportButtons(
 	parent: HTMLElement,
 	callbacks: TransportCallbacks,
 ): TransportElements {
-	const playPauseBtn = parent.createEl("button", {
+	const container = parent.createDiv({cls: "rpg-audio-transport"});
+
+	const playPauseBtn = container.createEl("button", {
 		cls: "rpg-audio-btn rpg-audio-play-btn clickable-icon",
 	});
 	setIcon(playPauseBtn, "play");
 	playPauseBtn.setAttribute("aria-label", "Play");
 
-	const stopBtn = parent.createEl("button", {
+	const stopBtn = container.createEl("button", {
 		cls: "rpg-audio-btn rpg-audio-stop-btn clickable-icon",
 	});
 	setIcon(stopBtn, "square");
@@ -39,7 +42,7 @@ export function createTransportButtons(
 	});
 	stopBtn.addEventListener("click", () => callbacks.onStop());
 
-	return {playPauseBtn, stopBtn};
+	return {container, playPauseBtn, stopBtn};
 }
 
 export function updatePlayPauseButton(btn: HTMLButtonElement, state: PlayState): void {

--- a/src/ui/sidebar-view.ts
+++ b/src/ui/sidebar-view.ts
@@ -378,14 +378,12 @@ export class RpgAudioSidebarView extends ItemView {
 		badge.setText(track.def.type.toUpperCase());
 		badge.dataset.type = track.def.type.toLowerCase();
 
-		// Row 2: settings buttons + volume (hidden in stopped state via CSS)
-		const row2 = row.createDiv({cls: "rpg-audio-sidebar-track-row2"});
-
-		const settings = createSettingsButtons(row2, track.def, (newLoop) => {
+		// Settings + volume on the same row (hidden in stopped state via CSS)
+		const settings = createSettingsButtons(row1, track.def, (newLoop) => {
 			this.manager.setLoopOverride(track.def.id, newLoop);
 		});
 
-		const volumeSlider = createVolumeControl(row2, (v) => {
+		const volumeSlider = createVolumeControl(row1, (v) => {
 			this.manager.setTrackVolume(track.def.id, v);
 		}, track.volume);
 

--- a/src/ui/sidebar-view.ts
+++ b/src/ui/sidebar-view.ts
@@ -14,6 +14,7 @@ import {
 	MIN_FADE_DURATION_MS,
 } from "../types";
 import {createPlayerControls, updatePlayPauseButton, PlayerControlsElements} from "./player-controls";
+import {formatTimestamp} from "./code-block-player";
 
 function formatCause(cause: TrackCause): string {
 	const kindLabel = cause.kind === "user" ? "" : ` (${cause.kind})`;
@@ -334,6 +335,17 @@ export class RpgAudioSidebarView extends ItemView {
 			scopeEl.createSpan({text: track.def.scope.join(", ")});
 		} else {
 			scopeEl.createSpan({cls: "rpg-audio-debug-muted", text: "no scope"});
+		}
+
+		if (track.def.startTime !== null || track.def.endTime !== null) {
+			const regionEl = scopeEl.createDiv({cls: "rpg-audio-sidebar-track-debug"});
+			regionEl.createSpan({cls: "rpg-audio-debug-label", text: "region: "});
+			const startLabel = track.def.startTime !== null ? formatTimestamp(track.def.startTime) : "start";
+			const endLabel = track.def.endTime !== null ? formatTimestamp(track.def.endTime) : "end";
+			let regionText = `${startLabel} – ${endLabel}`;
+			if (track.def.fadeInDuration > 0) regionText += ` | fadein: ${track.def.fadeInDuration}s`;
+			if (track.def.fadeOutDuration > 0) regionText += ` | fadeout: ${track.def.fadeOutDuration}s`;
+			regionEl.createSpan({text: regionText});
 		}
 
 		if (track.lastCause) {

--- a/src/ui/sidebar-view.ts
+++ b/src/ui/sidebar-view.ts
@@ -14,7 +14,17 @@ import {
 	TrackCause,
 	MIN_FADE_DURATION_MS,
 } from "../types";
-import {createPlayerControls, updatePlayPauseButton, PlayerControlsElements, createSeekBar, updateSeekBar, SeekBarElements} from "./player-controls";
+import {
+	createTransportButtons,
+	createVolumeControl,
+	createSettingsButtons,
+	createSeekBar,
+	updatePlayPauseButton,
+	updateSettingsButtons,
+	updateSeekBar,
+	SettingsButtonsElements,
+	SeekBarElements,
+} from "./player-controls";
 import {formatTimestamp} from "./code-block-player";
 
 function formatCause(cause: TrackCause): string {
@@ -23,10 +33,60 @@ function formatCause(cause: TrackCause): string {
 	return `${cause.action}${kindLabel}${detail}`;
 }
 
+interface TypeColorSet {
+	bg: string;
+	border: string;
+	text: string;
+	dim: string;
+}
+
+const TYPE_COLOR_MAP: Record<string, TypeColorSet> = {
+	music: {
+		bg: "rgba(124,92,191,0.06)",
+		border: "rgba(124,92,191,0.4)",
+		text: "#b8a0e0",
+		dim: "rgba(124,92,191,0.6)",
+	},
+	ambience: {
+		bg: "rgba(56,189,176,0.06)",
+		border: "rgba(56,189,176,0.4)",
+		text: "#5ecec7",
+		dim: "rgba(56,189,176,0.6)",
+	},
+	sfx: {
+		bg: "rgba(232,168,84,0.06)",
+		border: "rgba(232,168,84,0.4)",
+		text: "#e8a854",
+		dim: "rgba(232,168,84,0.6)",
+	},
+};
+
+const DEFAULT_COLORS: TypeColorSet = {
+	bg: "rgba(124,92,191,0.06)",
+	border: "rgba(124,92,191,0.4)",
+	text: "#b8a0e0",
+	dim: "rgba(124,92,191,0.6)",
+};
+
+function getTypeColors(type: string): TypeColorSet {
+	return TYPE_COLOR_MAP[type.toLowerCase()] ?? DEFAULT_COLORS;
+}
+
+interface TrackRowData {
+	rowEl: HTMLElement;
+	playPauseBtn: HTMLButtonElement;
+	volumeSlider: HTMLInputElement;
+	statusEl: HTMLElement;
+	debugEl: HTMLElement;
+	scopeEl: HTMLElement;
+	seekBar: SeekBarElements;
+	settings?: SettingsButtonsElements;
+}
+
 export class RpgAudioSidebarView extends ItemView {
 	private plugin: RpgAudioPlugin;
 	private manager: AudioManager;
-	private trackRows: Map<string, {rowEl: HTMLElement; controls: PlayerControlsElements; statusEl: HTMLElement; debugEl: HTMLElement; scopeEl: HTMLElement; seekBar: SeekBarElements}> = new Map();
+	private trackRows: Map<string, TrackRowData> = new Map();
 	private contentArea: HTMLElement | null = null;
 	private masterSlider: HTMLInputElement | null = null;
 	private autoplayBtn: HTMLElement | null = null;
@@ -90,7 +150,7 @@ export class RpgAudioSidebarView extends ItemView {
 				const row = this.trackRows.get(id);
 				if (!row) return;
 				const region = this.manager.getEffectiveRegion(id);
-				updateSeekBar(row.seekBar, currentTime, duration, region);
+				updateSeekBar(row.seekBar, currentTime, duration, region, PlayState.Playing);
 			})
 		);
 	}
@@ -244,6 +304,13 @@ export class RpgAudioSidebarView extends ItemView {
 			const section = this.contentArea.createDiv({cls: "rpg-audio-sidebar-section"});
 			const isCollapsed = this.collapsedGroups.has(type);
 
+			// Apply type-specific colour tokens to the section
+			const colors = getTypeColors(type);
+			section.style.setProperty("--type-bg", colors.bg);
+			section.style.setProperty("--type-border", colors.border);
+			section.style.setProperty("--type-text", colors.text);
+			section.style.setProperty("--type-dim", colors.dim);
+
 			const sectionHeader = section.createDiv({
 				cls: "rpg-audio-sidebar-section-header" + (isCollapsed ? " is-collapsed" : ""),
 			});
@@ -293,21 +360,40 @@ export class RpgAudioSidebarView extends ItemView {
 	private buildTrackRow(parent: HTMLElement, track: AudioTrackState): void {
 		const row = parent.createDiv({cls: "rpg-audio-sidebar-track"});
 		this.applyPlayStateClass(row, track.playState);
-		const topRow = row.createDiv({cls: "rpg-audio-sidebar-track-top"});
-		topRow.createDiv({cls: "rpg-audio-sidebar-track-name", text: track.def.name});
 
-		const controls = createPlayerControls(topRow, {
+		// Row 1: transport buttons + name + badge
+		const row1 = row.createDiv({cls: "rpg-audio-sidebar-track-top"});
+
+		const transport = createTransportButtons(row1, {
 			onPlay: () => void this.manager.play(track.def.id),
 			onPause: () => this.manager.pause(track.def.id),
 			onStop: () => this.manager.stop(track.def.id),
-			onVolumeChange: (v) => this.manager.setTrackVolume(track.def.id, v),
+		});
+		updatePlayPauseButton(transport.playPauseBtn, track.playState);
+
+		const nameEl = row1.createDiv({cls: "rpg-audio-sidebar-track-name", text: track.def.name});
+		nameEl.setAttribute("title", track.def.name);
+
+		const badge = row1.createSpan({cls: "rpg-audio-badge"});
+		badge.setText(track.def.type.toUpperCase());
+		badge.dataset.type = track.def.type.toLowerCase();
+
+		// Row 2: settings buttons + volume (hidden in stopped state via CSS)
+		const row2 = row.createDiv({cls: "rpg-audio-sidebar-track-row2"});
+
+		const settings = createSettingsButtons(row2, track.def, (newLoop) => {
+			this.manager.setLoopOverride(track.def.id, newLoop);
+		});
+
+		const volumeSlider = createVolumeControl(row2, (v) => {
+			this.manager.setTrackVolume(track.def.id, v);
 		}, track.volume);
 
-		updatePlayPauseButton(controls.playPauseBtn, track.playState);
-
+		// Status (errors + playlist index)
 		const statusEl = row.createDiv({cls: "rpg-audio-status"});
 		this.setStatusText(statusEl, track);
 
+		// Seek bar (hidden in stopped state via CSS)
 		const seekBar = createSeekBar(row, {
 			onSeek: (time) => this.manager.seek(track.def.id, time),
 			onRegionChange: (start, end) => this.manager.setEffectiveRegion(track.def.id, start, end),
@@ -317,7 +403,16 @@ export class RpgAudioSidebarView extends ItemView {
 		const debugEl = row.createDiv({cls: "rpg-audio-sidebar-track-debug"});
 		this.updateDebugEls(scopeEl, debugEl, track);
 
-		this.trackRows.set(track.def.id, {rowEl: row, controls, statusEl, debugEl, scopeEl, seekBar});
+		this.trackRows.set(track.def.id, {
+			rowEl: row,
+			playPauseBtn: transport.playPauseBtn,
+			volumeSlider,
+			statusEl,
+			debugEl,
+			scopeEl,
+			seekBar,
+			settings,
+		});
 	}
 
 	private updateTrackRow(id: string): void {
@@ -326,14 +421,18 @@ export class RpgAudioSidebarView extends ItemView {
 		if (!row || !state) return;
 
 		this.applyPlayStateClass(row.rowEl, state.playState);
-		updatePlayPauseButton(row.controls.playPauseBtn, state.playState);
-		row.controls.volumeSlider.value = String(state.volume);
+		updatePlayPauseButton(row.playPauseBtn, state.playState);
+		row.volumeSlider.value = String(state.volume);
 		this.setStatusText(row.statusEl, state);
+
+		if (row.settings) {
+			updateSettingsButtons(row.settings, this.manager.getEffectiveLoop(id));
+		}
 
 		const currentTime = this.manager.getCurrentTime(id);
 		const duration = this.manager.getDuration(id);
 		const region = this.manager.getEffectiveRegion(id);
-		updateSeekBar(row.seekBar, currentTime, duration, region);
+		updateSeekBar(row.seekBar, currentTime, duration, region, state.playState);
 
 		this.updateDebugEls(row.scopeEl, row.debugEl, state);
 	}

--- a/src/ui/sidebar-view.ts
+++ b/src/ui/sidebar-view.ts
@@ -9,11 +9,12 @@ import {
 	EVENT_MASTER_VOLUME,
 	EVENT_ALLOW_AUTOPLAY,
 	EVENT_ACTIVE_SCOPE_CHANGED,
+	EVENT_TIME_UPDATE,
 	AudioTrackState,
 	TrackCause,
 	MIN_FADE_DURATION_MS,
 } from "../types";
-import {createPlayerControls, updatePlayPauseButton, PlayerControlsElements} from "./player-controls";
+import {createPlayerControls, updatePlayPauseButton, PlayerControlsElements, createSeekBar, updateSeekBar, SeekBarElements} from "./player-controls";
 import {formatTimestamp} from "./code-block-player";
 
 function formatCause(cause: TrackCause): string {
@@ -25,7 +26,7 @@ function formatCause(cause: TrackCause): string {
 export class RpgAudioSidebarView extends ItemView {
 	private plugin: RpgAudioPlugin;
 	private manager: AudioManager;
-	private trackRows: Map<string, {rowEl: HTMLElement; controls: PlayerControlsElements; statusEl: HTMLElement; debugEl: HTMLElement; scopeEl: HTMLElement}> = new Map();
+	private trackRows: Map<string, {rowEl: HTMLElement; controls: PlayerControlsElements; statusEl: HTMLElement; debugEl: HTMLElement; scopeEl: HTMLElement; seekBar: SeekBarElements}> = new Map();
 	private contentArea: HTMLElement | null = null;
 	private masterSlider: HTMLInputElement | null = null;
 	private autoplayBtn: HTMLElement | null = null;
@@ -83,6 +84,14 @@ export class RpgAudioSidebarView extends ItemView {
 		);
 		this.registerEvent(
 			this.manager.on(EVENT_ACTIVE_SCOPE_CHANGED, () => this.updateActiveScope())
+		);
+		this.registerEvent(
+			this.manager.on(EVENT_TIME_UPDATE, (id: string, currentTime: number, duration: number) => {
+				const row = this.trackRows.get(id);
+				if (!row) return;
+				const region = this.manager.getEffectiveRegion(id);
+				updateSeekBar(row.seekBar, currentTime, duration, region);
+			})
 		);
 	}
 
@@ -299,11 +308,16 @@ export class RpgAudioSidebarView extends ItemView {
 		const statusEl = row.createDiv({cls: "rpg-audio-status"});
 		this.setStatusText(statusEl, track);
 
+		const seekBar = createSeekBar(row, {
+			onSeek: (time) => this.manager.seek(track.def.id, time),
+			onRegionChange: (start, end) => this.manager.setEffectiveRegion(track.def.id, start, end),
+		});
+
 		const scopeEl = row.createDiv({cls: "rpg-audio-sidebar-track-scope"});
 		const debugEl = row.createDiv({cls: "rpg-audio-sidebar-track-debug"});
 		this.updateDebugEls(scopeEl, debugEl, track);
 
-		this.trackRows.set(track.def.id, {rowEl: row, controls, statusEl, debugEl, scopeEl});
+		this.trackRows.set(track.def.id, {rowEl: row, controls, statusEl, debugEl, scopeEl, seekBar});
 	}
 
 	private updateTrackRow(id: string): void {
@@ -315,6 +329,12 @@ export class RpgAudioSidebarView extends ItemView {
 		updatePlayPauseButton(row.controls.playPauseBtn, state.playState);
 		row.controls.volumeSlider.value = String(state.volume);
 		this.setStatusText(row.statusEl, state);
+
+		const currentTime = this.manager.getCurrentTime(id);
+		const duration = this.manager.getDuration(id);
+		const region = this.manager.getEffectiveRegion(id);
+		updateSeekBar(row.seekBar, currentTime, duration, region);
+
 		this.updateDebugEls(row.scopeEl, row.debugEl, state);
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -3,14 +3,21 @@
 /* Inline code block player */
 .rpg-audio-player {
 	display: flex;
-	align-items: center;
-	gap: 8px;
+	flex-direction: column;
+	gap: 4px;
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 6px;
 	padding: 4px 8px;
 	margin: 4px 0;
 	background: var(--background-secondary);
 	border-left: 3px solid transparent;
+}
+
+.rpg-audio-player-top {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
 }
 
 .rpg-audio-player.is-playing {
@@ -372,6 +379,114 @@
 	text-align: center;
 	padding: 24px 12px;
 	font-style: italic;
+}
+
+/* Info badges on inline player */
+.rpg-audio-info {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+	font-size: 0.7em;
+	color: var(--text-muted);
+	padding: 0 2px;
+}
+
+.rpg-audio-info:empty {
+	display: none;
+}
+
+.rpg-audio-info-badge {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+}
+
+.rpg-audio-info-badge svg {
+	width: 10px;
+	height: 10px;
+}
+
+/* Seek bar */
+.rpg-audio-seek-container {
+	--region-start: 0%;
+	--region-end: 100%;
+	--seek-progress: 0%;
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	width: 100%;
+	padding: 2px 0;
+}
+
+.is-stopped > .rpg-audio-seek-container {
+	display: none;
+}
+
+.rpg-audio-seek {
+	flex: 1;
+	height: 4px;
+	-webkit-appearance: none;
+	appearance: none;
+	outline: none;
+	border-radius: 2px;
+	touch-action: pan-x;
+	background: linear-gradient(to right,
+		var(--background-modifier-border) 0%,
+		var(--background-modifier-border) var(--region-start),
+		var(--interactive-accent) var(--region-start),
+		var(--interactive-accent) var(--seek-progress),
+		var(--interactive-normal) var(--seek-progress),
+		var(--interactive-normal) var(--region-end),
+		var(--background-modifier-border) var(--region-end),
+		var(--background-modifier-border) 100%
+	);
+}
+
+.rpg-audio-seek::-webkit-slider-thumb {
+	-webkit-appearance: none;
+	appearance: none;
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	background: var(--interactive-accent);
+	cursor: pointer;
+	position: relative;
+	z-index: 2;
+}
+
+.rpg-audio-time {
+	font-size: 0.7em;
+	color: var(--text-muted);
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+/* Region handles */
+.rpg-audio-region-handle {
+	position: absolute;
+	width: 2px;
+	height: 14px;
+	background: var(--interactive-accent);
+	border-radius: 1px;
+	cursor: ew-resize;
+	z-index: 3;
+	top: 50%;
+	transform: translateY(-50%) translateX(-50%);
+	touch-action: none;
+}
+
+.rpg-audio-region-handle::before {
+	content: "";
+	position: absolute;
+	top: -4px;
+	left: -4px;
+	right: -4px;
+	bottom: -4px;
+}
+
+.rpg-audio-region-handle.is-hidden {
+	display: none;
 }
 
 /* Insert track modal */

--- a/styles.css
+++ b/styles.css
@@ -1,104 +1,95 @@
 /* RPG Audio Plugin Styles */
 
-/* Inline code block player */
+/* ── Inline code block player ─────────────────────────────────────────────── */
+
 .rpg-audio-player {
 	display: flex;
 	flex-direction: column;
-	gap: 4px;
+	gap: 6px;
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 6px;
-	padding: 4px 8px;
+	padding: 10px 14px;
 	margin: 4px 0;
 	background: var(--background-secondary);
 	border-left: 3px solid transparent;
 }
 
-.rpg-audio-player-top {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	width: 100%;
-}
-
 .rpg-audio-player.is-playing {
-	border-left-color: var(--color-green);
+	border-left-color: #4ade80;
 }
 
 .rpg-audio-player.is-paused {
-	border-left-color: var(--color-yellow);
-	opacity: 0.6;
+	border-left-color: #eab308;
+	opacity: 0.8;
 }
 
 .rpg-audio-player.is-stopped {
-	opacity: 0.7;
+	opacity: 0.55;
 }
 
-.rpg-audio-header {
+/* Top row: [play][stop] name badge [loop][fade] [vol] */
+.rpg-audio-player-top {
 	display: flex;
 	align-items: center;
 	gap: 6px;
-	min-width: 0;
-	flex-shrink: 1;
-}
-
-.rpg-audio-icon {
-	display: flex;
-	align-items: center;
-	color: var(--text-accent);
-	flex-shrink: 0;
-}
-
-.rpg-audio-icon svg {
-	width: 14px;
-	height: 14px;
+	width: 100%;
 }
 
 .rpg-audio-name {
 	font-weight: 600;
-	font-size: 0.9em;
+	font-size: 13px;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	flex: 1;
+	min-width: 0;
 }
+
+/* ── Type badge ───────────────────────────────────────────────────────────── */
 
 .rpg-audio-badge {
-	font-size: 0.65em;
-	padding: 1px 6px;
-	border-radius: 8px;
-	background: var(--background-modifier-border);
-	color: var(--text-muted);
+	font-size: 9px;
+	font-weight: 600;
+	letter-spacing: 0.5px;
+	padding: 2px 6px;
+	border-radius: 3px;
 	text-transform: uppercase;
-	letter-spacing: 0.05em;
 	flex-shrink: 0;
+	/* Default: music / unknown */
+	color: #7c5cbf;
+	background: rgba(124,92,191,0.12);
 }
 
-.rpg-audio-status-inline {
-	font-size: 0.75em;
-	color: var(--text-muted);
-	flex-shrink: 0;
+.rpg-audio-badge[data-type="sfx"] {
+	color: #e8a854;
+	background: rgba(232,168,84,0.1);
 }
 
-/* Shared controls */
-.rpg-audio-controls {
-	display: flex;
-	align-items: center;
-	gap: 4px;
-	margin-left: auto;
-	flex-shrink: 0;
+.rpg-audio-badge[data-type="ambience"] {
+	color: #38bdb0;
+	background: rgba(56,189,176,0.1);
 }
+
+.rpg-audio-badge[data-type="playlist"] {
+	color: #7c5cbf;
+	background: rgba(124,92,191,0.12);
+}
+
+/* ── Buttons ──────────────────────────────────────────────────────────────── */
 
 .rpg-audio-btn {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 24px;
-	height: 24px;
+	width: 30px;
+	height: 30px;
 	padding: 0;
 	border: none;
-	border-radius: 4px;
+	border-radius: 50%;
 	background: var(--interactive-normal);
 	color: var(--text-normal);
 	cursor: pointer;
+	flex-shrink: 0;
 }
 
 .rpg-audio-btn:hover {
@@ -106,16 +97,102 @@
 }
 
 .rpg-audio-btn svg {
+	width: 13px;
+	height: 13px;
+}
+
+/* State-tinted play button */
+.rpg-audio-play-btn.is-state-playing {
+	background: rgba(74,222,128,0.15);
+	color: #4ade80;
+}
+
+.rpg-audio-play-btn.is-state-paused {
+	background: rgba(234,179,8,0.12);
+	color: #eab308;
+}
+
+.rpg-audio-play-btn.is-state-stopped {
+	background: rgba(255,255,255,0.06);
+	color: #888a90;
+}
+
+/* Hide stop button and volume when stopped (inline player) */
+.rpg-audio-player.is-stopped .rpg-audio-stop-btn,
+.rpg-audio-player.is-stopped .rpg-audio-vol-wrapper,
+.rpg-audio-player.is-stopped .rpg-audio-seek-wrapper {
+	display: none;
+}
+
+/* ── Settings buttons (loop toggle + fade indicator) ─────────────────────── */
+
+.rpg-audio-settings-buttons {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
+}
+
+.rpg-audio-settings-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 18px;
+	height: 18px;
+	padding: 0;
+	border: none;
+	border-radius: 3px;
+	background: rgba(255,255,255,0.04);
+	color: #444;
+	cursor: pointer;
+	flex-shrink: 0;
+}
+
+.rpg-audio-settings-btn svg {
+	width: 11px;
+	height: 11px;
+}
+
+.rpg-audio-settings-btn.is-active {
+	background: rgba(184,160,224,0.15);
+	color: #b8a0e0;
+}
+
+.rpg-audio-settings-btn:hover {
+	background: rgba(255,255,255,0.08);
+}
+
+.rpg-audio-settings-btn.is-active:hover {
+	background: rgba(184,160,224,0.22);
+}
+
+/* ── Volume control ───────────────────────────────────────────────────────── */
+
+.rpg-audio-vol-wrapper {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
+}
+
+.rpg-audio-vol-icon {
+	display: flex;
+	align-items: center;
+	opacity: 0.35;
+	flex-shrink: 0;
+}
+
+.rpg-audio-vol-icon svg {
 	width: 12px;
 	height: 12px;
 }
 
 .rpg-audio-volume {
-	width: 60px;
-	height: 4px;
+	width: 40px;
+	height: 3px;
 	-webkit-appearance: none;
 	appearance: none;
-	background: var(--background-modifier-border);
+	background: rgba(255,255,255,0.06);
 	border-radius: 2px;
 	outline: none;
 	touch-action: pan-x;
@@ -124,23 +201,147 @@
 .rpg-audio-volume::-webkit-slider-thumb {
 	-webkit-appearance: none;
 	appearance: none;
-	width: 12px;
-	height: 12px;
+	width: 10px;
+	height: 10px;
 	border-radius: 50%;
-	background: var(--interactive-accent);
+	background: rgba(255,255,255,0.2);
 	cursor: pointer;
 }
 
-/* Status line — only used in sidebar track rows */
-.rpg-audio-status {
-	font-size: 0.75em;
-	color: var(--text-muted);
-	margin-top: 1px;
+.rpg-audio-volume::-webkit-slider-thumb:hover {
+	background: var(--interactive-accent);
 }
 
-.rpg-audio-status:empty {
+/* ── Seek bar ─────────────────────────────────────────────────────────────── */
+
+.rpg-audio-seek-wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	width: 100%;
+}
+
+/* Hide seek wrapper when stopped */
+.rpg-audio-player.is-stopped .rpg-audio-seek-wrapper,
+.rpg-audio-sidebar-track.is-stopped .rpg-audio-seek-wrapper {
 	display: none;
 }
+
+.rpg-audio-seek-container {
+	position: relative;
+	width: 100%;
+	height: 20px;
+	display: flex;
+	align-items: center;
+}
+
+/* Visual gradient track (rendered in JS) */
+.rpg-audio-seek-track {
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: 50%;
+	transform: translateY(-50%);
+	height: 10px;
+	border-radius: 5px;
+	z-index: 0;
+	pointer-events: none;
+	background: rgba(255,255,255,0.05);
+}
+
+/* Transparent range input — only thumb is visible */
+.rpg-audio-seek {
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: 0;
+	bottom: 0;
+	width: 100%;
+	height: 100%;
+	-webkit-appearance: none;
+	appearance: none;
+	background: transparent;
+	outline: none;
+	cursor: pointer;
+	z-index: 1;
+	margin: 0;
+	padding: 0;
+}
+
+.rpg-audio-seek::-webkit-slider-runnable-track {
+	background: transparent;
+	height: 10px;
+	border-radius: 5px;
+}
+
+.rpg-audio-seek::-webkit-slider-thumb {
+	-webkit-appearance: none;
+	appearance: none;
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	background: #fff;
+	cursor: pointer;
+	box-shadow: 0 1px 5px rgba(0,0,0,0.5), 0 0 0 2px rgba(124,92,191,0.3);
+}
+
+/* Paused: muted thumb */
+.is-paused .rpg-audio-seek::-webkit-slider-thumb {
+	background: rgba(255,255,255,0.7);
+}
+
+/* ── Region handles ───────────────────────────────────────────────────────── */
+
+.rpg-audio-region-handle {
+	position: absolute;
+	width: 6px;
+	height: 18px;
+	background: #b8a0e0;
+	border-radius: 3px;
+	border: 1px solid rgba(255,255,255,0.15);
+	box-shadow: 0 0 6px rgba(124,92,191,0.5);
+	cursor: ew-resize;
+	z-index: 3;
+	top: 50%;
+	transform: translateY(-50%) translateX(-50%);
+	touch-action: none;
+}
+
+.rpg-audio-region-handle::before {
+	content: "";
+	position: absolute;
+	top: -6px;
+	left: -6px;
+	right: -6px;
+	bottom: -6px;
+}
+
+/* Dormant handles: parked at edges, muted appearance, no glow */
+.rpg-audio-region-handle.is-dormant {
+	width: 5px;
+	height: 16px;
+	background: rgba(184,160,224,0.3);
+	border: 1px solid rgba(255,255,255,0.08);
+	box-shadow: none;
+}
+
+/* ── Time row ─────────────────────────────────────────────────────────────── */
+
+.rpg-audio-time-row {
+	display: flex;
+	justify-content: space-between;
+	font-size: 10px;
+	color: #555860;
+	font-variant-numeric: tabular-nums;
+	line-height: 1;
+}
+
+.rpg-audio-time-center {
+	font-size: 9px;
+	color: #666;
+}
+
+/* ── Inline player status ─────────────────────────────────────────────────── */
 
 .rpg-audio-error {
 	color: var(--text-error);
@@ -154,7 +355,8 @@
 	color: var(--text-error);
 }
 
-/* Sidebar */
+/* ── Sidebar ──────────────────────────────────────────────────────────────── */
+
 .rpg-audio-sidebar {
 	padding: 0;
 	display: flex;
@@ -165,7 +367,7 @@
 
 .rpg-audio-sidebar-header {
 	padding: 12px;
-	border-bottom: 1px solid var(--background-modifier-border);
+	border-bottom: 1px solid rgba(255,255,255,0.06);
 }
 
 .rpg-audio-sidebar-title-row {
@@ -184,7 +386,7 @@
 
 .rpg-audio-sidebar-title {
 	font-weight: 700;
-	font-size: 1.1em;
+	font-size: 14px;
 }
 
 .rpg-audio-stop-all-btn {
@@ -210,6 +412,7 @@
 
 .rpg-audio-master-volume {
 	flex: 1;
+	width: auto;
 }
 
 .rpg-audio-sidebar-content {
@@ -221,7 +424,7 @@
 
 .rpg-audio-sidebar-footer {
 	padding: 6px 12px;
-	border-top: 1px solid var(--background-modifier-border);
+	border-top: 1px solid rgba(255,255,255,0.06);
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
@@ -251,7 +454,7 @@
 
 .rpg-audio-sidebar-track-scope,
 .rpg-audio-sidebar-track-debug {
-	font-size: 0.72em;
+	font-size: 9px;
 	color: var(--text-muted);
 	font-family: var(--font-monospace);
 	margin-top: 2px;
@@ -277,8 +480,10 @@
 	color: var(--text-muted);
 }
 
+/* ── Section headers ──────────────────────────────────────────────────────── */
+
 .rpg-audio-sidebar-section {
-	margin-bottom: 16px;
+	margin-bottom: 8px;
 }
 
 .rpg-audio-sidebar-section-header {
@@ -286,19 +491,21 @@
 	align-items: center;
 	gap: 6px;
 	font-weight: 600;
-	font-size: 0.85em;
+	font-size: 10px;
 	text-transform: uppercase;
-	letter-spacing: 0.05em;
-	color: var(--text-muted);
-	padding: 6px 4px;
-	border-bottom: 1px solid var(--background-modifier-border);
+	letter-spacing: 0.8px;
+	padding: 8px 12px;
 	cursor: pointer;
 	user-select: none;
 	border-radius: 4px;
+	/* Type colour tokens set via JS */
+	background: var(--type-bg, rgba(124,92,191,0.06));
+	border-left: 2px solid var(--type-border, rgba(124,92,191,0.4));
+	color: var(--type-text, #b8a0e0);
 }
 
 .rpg-audio-sidebar-section-header:hover {
-	background: var(--background-modifier-hover);
+	filter: brightness(1.1);
 }
 
 .rpg-audio-section-chevron {
@@ -308,8 +515,8 @@
 }
 
 .rpg-audio-section-chevron svg {
-	width: 14px;
-	height: 14px;
+	width: 12px;
+	height: 12px;
 }
 
 .rpg-audio-sidebar-section-header.is-collapsed .rpg-audio-section-chevron {
@@ -317,13 +524,13 @@
 }
 
 .rpg-audio-section-count {
-	margin-left: auto;
-	font-size: 0.85em;
-	color: var(--text-faint);
+	font-size: 9px;
+	color: var(--type-dim, rgba(124,92,191,0.6));
 	font-weight: 400;
 }
 
 .rpg-audio-section-fade-btn {
+	margin-left: auto;
 	opacity: 1;
 }
 
@@ -336,43 +543,93 @@
 	padding-top: 4px;
 }
 
+/* ── Sidebar track rows ───────────────────────────────────────────────────── */
+
 .rpg-audio-sidebar-track {
-	padding: 4px 8px;
+	padding: 8px 10px 8px 9px;
 	border-radius: 6px;
 	margin-bottom: 2px;
 	border-left: 3px solid transparent;
 }
 
 .rpg-audio-sidebar-track.is-playing {
-	border-left-color: var(--color-green);
+	border-left-color: #4ade80;
+	background: rgba(74,222,128,0.02);
 }
 
 .rpg-audio-sidebar-track.is-paused {
-	border-left-color: var(--color-yellow);
-	opacity: 0.6;
+	border-left-color: #eab308;
+	opacity: 0.8;
 }
 
 .rpg-audio-sidebar-track.is-stopped {
-	opacity: 0.7;
+	opacity: 0.55;
+	border-left-color: transparent;
+	padding-left: 12px;
 }
 
 .rpg-audio-sidebar-track:hover {
 	background: var(--background-modifier-hover);
 }
 
+.rpg-audio-sidebar-track.is-playing:hover {
+	background: rgba(74,222,128,0.04);
+}
+
+/* Row 1: transport + name + badge */
 .rpg-audio-sidebar-track-top {
 	display: flex;
 	align-items: center;
 	gap: 6px;
 }
 
+/* Sidebar buttons are slightly smaller than inline */
+.rpg-audio-sidebar-track .rpg-audio-btn {
+	width: 26px;
+	height: 26px;
+}
+
+.rpg-audio-sidebar-track .rpg-audio-btn svg {
+	width: 11px;
+	height: 11px;
+}
+
 .rpg-audio-sidebar-track-name {
-	font-weight: 500;
+	font-size: 12px;
+	font-weight: 600;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	flex: 1;
 	min-width: 0;
 }
+
+/* Row 2: settings + volume — hidden when stopped */
+.rpg-audio-sidebar-track-row2 {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 4px;
+	justify-content: flex-end;
+}
+
+.rpg-audio-sidebar-track.is-stopped .rpg-audio-sidebar-track-row2,
+.rpg-audio-sidebar-track.is-stopped .rpg-audio-stop-btn {
+	display: none;
+}
+
+/* Status line (playlist index / errors) */
+.rpg-audio-status {
+	font-size: 0.75em;
+	color: var(--text-muted);
+	margin-top: 1px;
+}
+
+.rpg-audio-status:empty {
+	display: none;
+}
+
+/* ── Empty state ──────────────────────────────────────────────────────────── */
 
 .rpg-audio-empty-state {
 	color: var(--text-muted);
@@ -381,115 +638,8 @@
 	font-style: italic;
 }
 
-/* Info badges on inline player */
-.rpg-audio-info {
-	display: flex;
-	gap: 8px;
-	flex-wrap: wrap;
-	font-size: 0.7em;
-	color: var(--text-muted);
-	padding: 0 2px;
-}
+/* ── Insert track modal ───────────────────────────────────────────────────── */
 
-.rpg-audio-info:empty {
-	display: none;
-}
-
-.rpg-audio-info-badge {
-	display: flex;
-	align-items: center;
-	gap: 2px;
-}
-
-.rpg-audio-info-badge svg {
-	width: 10px;
-	height: 10px;
-}
-
-/* Seek bar */
-.rpg-audio-seek-container {
-	--region-start: 0%;
-	--region-end: 100%;
-	--seek-progress: 0%;
-	position: relative;
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	width: 100%;
-	padding: 2px 0;
-}
-
-.is-stopped > .rpg-audio-seek-container {
-	display: none;
-}
-
-.rpg-audio-seek {
-	flex: 1;
-	height: 4px;
-	-webkit-appearance: none;
-	appearance: none;
-	outline: none;
-	border-radius: 2px;
-	touch-action: pan-x;
-	background: linear-gradient(to right,
-		var(--background-modifier-border) 0%,
-		var(--background-modifier-border) var(--region-start),
-		var(--interactive-accent) var(--region-start),
-		var(--interactive-accent) var(--seek-progress),
-		var(--interactive-normal) var(--seek-progress),
-		var(--interactive-normal) var(--region-end),
-		var(--background-modifier-border) var(--region-end),
-		var(--background-modifier-border) 100%
-	);
-}
-
-.rpg-audio-seek::-webkit-slider-thumb {
-	-webkit-appearance: none;
-	appearance: none;
-	width: 10px;
-	height: 10px;
-	border-radius: 50%;
-	background: var(--interactive-accent);
-	cursor: pointer;
-	position: relative;
-	z-index: 2;
-}
-
-.rpg-audio-time {
-	font-size: 0.7em;
-	color: var(--text-muted);
-	white-space: nowrap;
-	flex-shrink: 0;
-}
-
-/* Region handles */
-.rpg-audio-region-handle {
-	position: absolute;
-	width: 2px;
-	height: 14px;
-	background: var(--interactive-accent);
-	border-radius: 1px;
-	cursor: ew-resize;
-	z-index: 3;
-	top: 50%;
-	transform: translateY(-50%) translateX(-50%);
-	touch-action: none;
-}
-
-.rpg-audio-region-handle::before {
-	content: "";
-	position: absolute;
-	top: -4px;
-	left: -4px;
-	right: -4px;
-	bottom: -4px;
-}
-
-.rpg-audio-region-handle.is-hidden {
-	display: none;
-}
-
-/* Insert track modal */
 .rpg-audio-insert-modal {
 	padding: 12px;
 }

--- a/styles.css
+++ b/styles.css
@@ -27,12 +27,29 @@
 	opacity: 0.55;
 }
 
-/* Top row: [play][stop] name badge [loop][fade] [vol] */
+/* Top row: [transport] [header] [controls] */
 .rpg-audio-player-top {
 	display: flex;
 	align-items: center;
 	gap: 6px;
 	width: 100%;
+}
+
+/* Transport buttons wrapper (play + stop side by side) */
+.rpg-audio-transport {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
+}
+
+/* Header (name + badge) — takes remaining space */
+.rpg-audio-header {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex: 1;
+	min-width: 0;
 }
 
 .rpg-audio-name {
@@ -41,8 +58,15 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	flex: 1;
-	min-width: 0;
+}
+
+/* Right-aligned controls (settings + volume) */
+.rpg-audio-controls {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+	margin-left: auto;
 }
 
 /* ── Type badge ───────────────────────────────────────────────────────────── */
@@ -117,9 +141,9 @@
 	color: #888a90;
 }
 
-/* Hide stop button and volume when stopped (inline player) */
+/* Hide controls + seek when stopped (inline player) */
 .rpg-audio-player.is-stopped .rpg-audio-stop-btn,
-.rpg-audio-player.is-stopped .rpg-audio-vol-wrapper,
+.rpg-audio-player.is-stopped .rpg-audio-controls,
 .rpg-audio-player.is-stopped .rpg-audio-seek-wrapper {
 	display: none;
 }
@@ -219,12 +243,6 @@
 	flex-direction: column;
 	gap: 3px;
 	width: 100%;
-}
-
-/* Hide seek wrapper when stopped */
-.rpg-audio-player.is-stopped .rpg-audio-seek-wrapper,
-.rpg-audio-sidebar-track.is-stopped .rpg-audio-seek-wrapper {
-	display: none;
 }
 
 .rpg-audio-seek-container {
@@ -330,10 +348,16 @@
 .rpg-audio-time-row {
 	display: flex;
 	justify-content: space-between;
+	align-items: center;
+	width: 100%;
 	font-size: 10px;
 	color: #555860;
 	font-variant-numeric: tabular-nums;
 	line-height: 1;
+}
+
+.rpg-audio-time-center:empty {
+	display: none;
 }
 
 .rpg-audio-time-center {
@@ -614,7 +638,8 @@
 }
 
 .rpg-audio-sidebar-track.is-stopped .rpg-audio-sidebar-track-row2,
-.rpg-audio-sidebar-track.is-stopped .rpg-audio-stop-btn {
+.rpg-audio-sidebar-track.is-stopped .rpg-audio-stop-btn,
+.rpg-audio-sidebar-track.is-stopped .rpg-audio-seek-wrapper {
 	display: none;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -27,29 +27,12 @@
 	opacity: 0.55;
 }
 
-/* Top row: [transport] [header] [controls] */
+/* Top row: [play][stop] name badge [loop][fade] [vol] */
 .rpg-audio-player-top {
 	display: flex;
 	align-items: center;
 	gap: 6px;
 	width: 100%;
-}
-
-/* Transport buttons wrapper (play + stop side by side) */
-.rpg-audio-transport {
-	display: flex;
-	align-items: center;
-	gap: 4px;
-	flex-shrink: 0;
-}
-
-/* Header (name + badge) — takes remaining space */
-.rpg-audio-header {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	flex: 1;
-	min-width: 0;
 }
 
 .rpg-audio-name {
@@ -58,15 +41,8 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-}
-
-/* Right-aligned controls (settings + volume) */
-.rpg-audio-controls {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	flex-shrink: 0;
-	margin-left: auto;
+	flex: 1;
+	min-width: 0;
 }
 
 /* ── Type badge ───────────────────────────────────────────────────────────── */
@@ -141,9 +117,9 @@
 	color: #888a90;
 }
 
-/* Hide controls + seek when stopped (inline player) */
+/* Hide stop button and volume when stopped (inline player) */
 .rpg-audio-player.is-stopped .rpg-audio-stop-btn,
-.rpg-audio-player.is-stopped .rpg-audio-controls,
+.rpg-audio-player.is-stopped .rpg-audio-vol-wrapper,
 .rpg-audio-player.is-stopped .rpg-audio-seek-wrapper {
 	display: none;
 }
@@ -245,12 +221,16 @@
 	width: 100%;
 }
 
+/* Hide seek wrapper when stopped */
+.rpg-audio-player.is-stopped .rpg-audio-seek-wrapper,
+.rpg-audio-sidebar-track.is-stopped .rpg-audio-seek-wrapper {
+	display: none;
+}
+
 .rpg-audio-seek-container {
 	position: relative;
 	width: 100%;
 	height: 20px;
-	display: flex;
-	align-items: center;
 }
 
 /* Visual gradient track (rendered in JS) */
@@ -269,16 +249,16 @@
 
 /* Transparent range input — only thumb is visible */
 .rpg-audio-seek {
-	position: absolute;
-	left: 0;
-	right: 0;
-	top: 0;
-	bottom: 0;
-	width: 100%;
-	height: 100%;
-	-webkit-appearance: none;
-	appearance: none;
-	background: transparent;
+	position: absolute !important;
+	left: 0 !important;
+	top: 0 !important;
+	right: 0 !important;
+	bottom: 0 !important;
+	width: 100% !important;
+	height: 100% !important;
+	-webkit-appearance: none !important;
+	appearance: none !important;
+	background: transparent !important;
 	outline: none;
 	cursor: pointer;
 	z-index: 1;
@@ -287,7 +267,7 @@
 }
 
 .rpg-audio-seek::-webkit-slider-runnable-track {
-	background: transparent;
+	background: transparent !important;
 	height: 10px;
 	border-radius: 5px;
 }
@@ -348,16 +328,10 @@
 .rpg-audio-time-row {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
-	width: 100%;
 	font-size: 10px;
 	color: #555860;
 	font-variant-numeric: tabular-nums;
 	line-height: 1;
-}
-
-.rpg-audio-time-center:empty {
-	display: none;
 }
 
 .rpg-audio-time-center {
@@ -628,18 +602,10 @@
 	min-width: 0;
 }
 
-/* Row 2: settings + volume — hidden when stopped */
-.rpg-audio-sidebar-track-row2 {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	margin-top: 4px;
-	justify-content: flex-end;
-}
-
-.rpg-audio-sidebar-track.is-stopped .rpg-audio-sidebar-track-row2,
+/* Hide stop/settings/volume when stopped in sidebar */
 .rpg-audio-sidebar-track.is-stopped .rpg-audio-stop-btn,
-.rpg-audio-sidebar-track.is-stopped .rpg-audio-seek-wrapper {
+.rpg-audio-sidebar-track.is-stopped .rpg-audio-settings-buttons,
+.rpg-audio-sidebar-track.is-stopped .rpg-audio-vol-wrapper {
 	display: none;
 }
 


### PR DESCRIPTION
## Summary
- Seek bar: 10px gradient track showing played/unplayed/region zones; transparent input overlay fixed with !important to survive Obsidian theme overrides
- Region handles: dormant at track edges, drag inward to create region, drag to edge to clear; active handles glow
- Loop override API: runtime loop toggle per track without mutating AudioTrackDef
- Settings buttons: icon-only loop toggle + fade indicator; aria-label only (fixes double tooltip)
- State tinting: play button tints green/amber/neutral for playing/paused/stopped
- Type badges: colour-coded (music=purple, ambience=teal, sfx=amber)
- Sidebar: per-type accent colours on section headers; single-row track layout matching inline player